### PR TITLE
Small fixes to docs

### DIFF
--- a/docs/setup_apple.md
+++ b/docs/setup_apple.md
@@ -274,7 +274,7 @@ Given everything that I said in this tutorial, here is how the `env` section wou
 ANDROID_SERVICE_ID = Service ID
 IOS_SERVICE_ID = App ID
 
-```json
+```js
 env: {
   PRIVATE_KEY_FILE: "AuthKey_U93M8LBQK3.p8",
   KEY_ID: "U93M8LBQK3",
@@ -284,7 +284,7 @@ env: {
   PORT: 3000,
   REDIRECT_URI: "https://xyz.wcaleniewolny.me/login/callback",
   BASE_REDIRECT_URL: "capgo-demo-app://path"
- }
+}
 ```
 
 #### Using the plugin

--- a/docs/setup_apple.md
+++ b/docs/setup_apple.md
@@ -257,7 +257,7 @@ As you saw in the diagram, the backend performs a step called `Redirect back to 
 
 #### Backend configuration
 
-A backend is required for Android, but configuring a backend will also imact IOS. An example backend is provided [here](https://github.com/WcaleNieWolny/capgo-social-login-backend-demo/blob/main/index.ts)
+A backend is required for Android, but configuring a backend will also impact IOS. An example backend is provided [here](https://github.com/WcaleNieWolny/capgo-social-login-backend-demo/blob/main/index.ts)
 
 This example provides the following:
 

--- a/docs/setup_apple.md
+++ b/docs/setup_apple.md
@@ -52,7 +52,7 @@ async function loginApple() {
     options: {}
   })
   // token = the JWT returned by Apple
-  const token = res.result.identityToken
+  const token = res.result.idToken
   // Send the token to your backend.... 
 }
 ```

--- a/docs/setup_google.md
+++ b/docs/setup_google.md
@@ -173,7 +173,6 @@ In this part, you will learn how to setup Google login in IOS
 
 - Save the file with `Command + S`
 
-- Save the file with `Command + S`
 4. Now, you should be ready to setup Google login in JS.
    
    - First, you need import `SocialLogin` AND `Capacitor`


### PR DESCRIPTION
I've been also thinking about removing [backend example](https://github.com/Cap-go/capacitor-social-login/blob/main/docs/example_backend.ts) which is not referenced anywhere

but the repo which is referenced instead seems to receive features (https://github.com/WcaleNieWolny/capgo-social-login-backend-demo/commit/141c01d93a85240e31a0d488a89df13c842708b1) that are not related to Sign In with Apple
