### PR TITLE
fix(apple): added missing nonce config

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/social/login/AppleProvider.java
+++ b/android/src/main/java/ee/forgr/capacitor/social/login/AppleProvider.java
@@ -180,6 +180,15 @@ public class AppleProvider implements SocialProvider {
       }
     }
 
+    String nonce = null;
+    if (config.has("nonce")) {
+        try {
+            nonce = config.getString("nonce");
+        } catch (JSONException e) {
+            Log.e(SocialLoginPlugin.LOG_TAG, "Error parsing nonce", e);
+        }
+    }
+
     this.appleAuthURLFull = AUTHURL +
     "?client_id=" +
     this.clientId +
@@ -190,6 +199,10 @@ public class AppleProvider implements SocialProvider {
     "&response_mode=form_post&state=" +
     state;
 
+    if (nonce != null) {
+        this.appleAuthURLFull += "&nonce=" + nonce;
+    }
+    
     if (context == null || activity == null) {
       call.reject("Context or Activity is null");
       return;

--- a/ios/Sources/SocialLoginPlugin/AppleProvider.swift
+++ b/ios/Sources/SocialLoginPlugin/AppleProvider.swift
@@ -197,6 +197,10 @@ class AppleProvider: NSObject, ASAuthorizationControllerDelegate, ASAuthorizatio
             request.requestedScopes = [.fullName, .email]
         }
 
+        if let nonce = payload["nonce"] as? String {
+            request.nonce = nonce;
+        }
+
         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController.delegate = self
         authorizationController.presentationContextProvider = self


### PR DESCRIPTION
Even though the plugin lets you configure nonce for the Apple provider, the plugin simply ignores this when making the native requests. I added the appropriate code to fix this for login requests.