### PR TITLE
feat: add hosted domain filter for Google login provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,11 +351,11 @@ Refresh the access token
 
 #### InitializeOptions
 
-| Prop           | Type                                                                                                                   |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| **`facebook`** | <code>{ appId: string; clientToken: string; }</code>                                                                   |
-| **`google`**   | <code>{ iOSClientId?: string; iOSServerClientId?: string; webClientId?: string; mode?: 'online' \| 'offline'; }</code> |
-| **`apple`**    | <code>{ clientId?: string; redirectUrl?: string; }</code>                                                              |
+| Prop           | Type                                                                                                                                          |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`facebook`** | <code>{ appId: string; clientToken: string; }</code>                                                                                          |
+| **`google`**   | <code>{ iOSClientId?: string; iOSServerClientId?: string; webClientId?: string; mode?: 'online' \| 'offline'; hostedDomain?: string; }</code> |
+| **`apple`**    | <code>{ clientId?: string; redirectUrl?: string; }</code>                                                                                     |
 
 
 #### FacebookLoginResponse

--- a/android/src/main/java/ee/forgr/capacitor/social/login/GoogleProvider.java
+++ b/android/src/main/java/ee/forgr/capacitor/social/login/GoogleProvider.java
@@ -76,6 +76,7 @@ public class GoogleProvider implements SocialProvider {
     private String idToken = null;
     private String accessToken = null;
     private GoogleProviderLoginType mode = GoogleProviderLoginType.ONLINE;
+    private String hostedDomain = null;
 
     public enum GoogleProviderLoginType {
         ONLINE,
@@ -91,10 +92,11 @@ public class GoogleProvider implements SocialProvider {
         }
     }
 
-    public void initialize(String clientId, GoogleProviderLoginType mode) {
+    public void initialize(String clientId, GoogleProviderLoginType mode, String hostedDomain) {
         this.credentialManager = CredentialManager.create(activity);
         this.clientId = clientId;
         this.mode = mode;
+        this.hostedDomain = hostedDomain;
 
         String data = context.getSharedPreferences(SHARED_PREFERENCE_NAME, Context.MODE_PRIVATE).getString(GOOGLE_DATA_PREFERENCE, null);
 
@@ -281,7 +283,7 @@ public class GoogleProvider implements SocialProvider {
             return;
         }
 
-        String nonce = call.getString("nonce");
+        String nonce = config.optString("nonce");
 
         // Extract scopes from the config
         JSONArray scopesArray = config.optJSONArray("scopes");
@@ -336,6 +338,10 @@ public class GoogleProvider implements SocialProvider {
 
         if (nonce != null && !nonce.isEmpty()) {
             googleIdOptionBuilder.setNonce(nonce);
+        }
+
+        if (this.hostedDomain != null && !this.hostedDomain.isEmpty()) {
+            googleIdOptionBuilder.setHostedDomainFilter(this.hostedDomain);
         }
 
         GetSignInWithGoogleOption googleIdOptionFiltered = googleIdOptionBuilder.build();

--- a/android/src/main/java/ee/forgr/capacitor/social/login/SocialLoginPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/social/login/SocialLoginPlugin.java
@@ -59,6 +59,7 @@ public class SocialLoginPlugin extends Plugin {
                 call.reject("google.clientId is null or empty");
                 return;
             }
+            String hostedDomain = google.getString("hostedDomain");
             String modestr = google.getString("mode", "online");
             GoogleProvider.GoogleProviderLoginType mode = null;
             switch (modestr) {
@@ -72,7 +73,7 @@ public class SocialLoginPlugin extends Plugin {
                     call.reject("google.mode != (online || offline)");
                     return;
             }
-            googleProvider.initialize(googleClientId, mode);
+            googleProvider.initialize(googleClientId, mode, hostedDomain);
             this.socialProviderHashMap.put("google", googleProvider);
         }
 

--- a/ios/Sources/SocialLoginPlugin/GoogleProvider.swift
+++ b/ios/Sources/SocialLoginPlugin/GoogleProvider.swift
@@ -13,8 +13,8 @@ class GoogleProvider {
     var defaultGrantedScopes = ["email", "profile", "openid"]
     var mode = GoogleProviderLoginType.ONLINE
 
-    func initialize(clientId: String, mode: GoogleProviderLoginType, serverClientId: String? = nil) {
-        configuration = GIDConfiguration(clientID: clientId, serverClientID: serverClientId)
+    func initialize(clientId: String, mode: GoogleProviderLoginType, serverClientId: String? = nil, hostedDomain: String? = nil) {
+        configuration = GIDConfiguration(clientID: clientId, serverClientID: serverClientId, hostedDomain: hostedDomain, openIDRealm: nil)
         self.mode = mode
 
         GIDSignIn.sharedInstance.configuration = configuration

--- a/ios/Sources/SocialLoginPlugin/SocialLoginPlugin.swift
+++ b/ios/Sources/SocialLoginPlugin/SocialLoginPlugin.swift
@@ -36,6 +36,7 @@ public class SocialLoginPlugin: CAPPlugin, CAPBridgedPlugin {
         if let googleSettings = call.getObject("google") {
             let iOSClientId = googleSettings["iOSClientId"] as? String
             let iOSServerClientId = googleSettings["iOSServerClientId"] as? String
+            let hostedDomain = googleSettings["hostedDomain"] as? String
 
             let modeStr = googleSettings["mode"] as? String
             var mode = GoogleProviderLoginType.ONLINE
@@ -52,11 +53,7 @@ public class SocialLoginPlugin: CAPPlugin, CAPBridgedPlugin {
             }
 
             if let clientId = iOSClientId {
-                if let serverClientId = iOSServerClientId {
-                    google.initialize(clientId: clientId, mode: mode, serverClientId: serverClientId)
-                } else {
-                    google.initialize(clientId: clientId, mode: mode, serverClientId: nil)
-                }
+                google.initialize(clientId: clientId, mode: mode, serverClientId: iOSServerClientId, hostedDomain: hostedDomain)
                 initialized = true
             }
         }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -38,6 +38,11 @@ export interface InitializeOptions {
      * @since 3.1.0
      */
     mode?: 'online' | 'offline';
+    /**
+     * Filter visible accounts by hosted domain
+     * @description filter visible accounts by hosted domain
+     */
+    hostedDomain?: string;
   };
   apple?: {
     /**


### PR DESCRIPTION
Adds support for hosted domain filtering in Google login, allowing authentication only from specified Google domains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced hosted domain support for Google login across platforms, allowing for domain-specific filtering during authentication.
- **Documentation**
	- Updated configuration guides to reflect the new hosted domain option and associated setup details for Google login.

These enhancements provide users with added flexibility when integrating Google login, enabling more tailored and secure authentication experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->