### PR TITLE
fix: facebook clientToken optional

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,7 +7,7 @@ export interface InitializeOptions {
     /**
      * Facebook Client Token, provided by Facebook for web, in mobile it's set in the native files
      */
-    clientToken: string;
+    clientToken?: string;
   };
 
   google?: {


### PR DESCRIPTION
si this, optional for web 
![CleanShot 2025-04-17 at 01 52 45@2x](https://github.com/user-attachments/assets/1fb0abc8-9819-4c43-9cba-620454338093)
