### PR TITLE
docs(setup_apple.md): data sharing

### DIFF
--- a/docs/setup_apple.md
+++ b/docs/setup_apple.md
@@ -28,6 +28,8 @@ Then, please make sure that you add the `Sign in with Apple` capability.
 
 ![](./assets/sign-with-apple-cap.png)
 
+If empty, configure the [Account & Organizational Data Sharing](https://developer.apple.com/account/resources/services/cwa/configure)
+
 Next, you want to initialize the Apple Login.
 
 | NOTE: I am using Vue as my framework, the exact implementation will vary depening on the framework of your choice |


### PR DESCRIPTION
Add the new required `services` Account & Organizational Data Sharing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Apple login setup instructions for iOS to include guidance on configuring "Account & Organizational Data Sharing" if the capability section is empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->