### PR TITLE
Fix Apple identityToken and authorizationCode mix up

### DIFF
--- a/ios/Sources/SocialLoginPlugin/AppleProvider.swift
+++ b/ios/Sources/SocialLoginPlugin/AppleProvider.swift
@@ -249,16 +249,18 @@ class AppleProvider: NSObject, ASAuthorizationControllerDelegate, ASAuthorizatio
             let finalFamilyName = fullName?.familyName ?? savedName?.familyName
 
             // Create proper access token and decode JWT
-            let tokenString = String(data: appleIDCredential.identityToken ?? Data(), encoding: .utf8) ?? ""
+            let authorizationCode = String(data: appleIDCredential.authorizationCode ?? Data(), encoding: .utf8) ?? ""
+            let idToken = String(data: appleIDCredential.identityToken ?? Data(), encoding: .utf8) ?? ""
+
             let accessToken = AccessTokenApple(
-                token: tokenString,
+                token: authorizationCode,
                 expiresIn: 3600,
                 refreshToken: nil
             )
 
             // Decode JWT to get email
             var decodedEmail = email
-            if let jwt = tokenString.split(separator: ".").dropFirst().first {
+            if let jwt = idToken.split(separator: ".").dropFirst().first {
                 let remainder = jwt.count % 4
                 var base64String = String(jwt)
                 if remainder > 0 {
@@ -280,7 +282,7 @@ class AppleProvider: NSObject, ASAuthorizationControllerDelegate, ASAuthorizatio
                     givenName: finalGivenName,
                     familyName: finalFamilyName
                 ),
-                idToken: String(data: appleIDCredential.authorizationCode ?? Data(), encoding: .utf8) ?? ""
+                idToken: idToken
             )
 
             if !self.redirectUrl.isEmpty {

--- a/src/apple-provider.ts
+++ b/src/apple-provider.ts
@@ -48,9 +48,9 @@ export class AppleSocialLogin extends BaseSocialLogin {
               familyName: res.user?.name?.lastName || null,
             },
             accessToken: {
-              token: res.authorization.id_token || '',
+              token: res.authorization.code || '',
             },
-            idToken: res.authorization.code || null,
+            idToken: res.authorization.id_token || null,
           };
           resolve({ provider: 'apple', result });
         })


### PR DESCRIPTION
Fixes #229, which has complex description of a problem.

Before this PR plugin was returning *authorization code* instead of *identity token* (JWT) and *identity token* instead of *authorization code*.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected Apple Sign-In token mapping: idToken is now properly populated with the Apple ID token, and access tokens derive from the authorization code.
  - Fixed email retrieval during Apple login by decoding the correct token, improving sign-in reliability and consistency across platforms.
  - Ensures consistent response fields for Apple authentication, reducing confusion and integration issues for clients relying on idToken and authorization code values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->