### PR TITLE
Fix Android Studio builds by downgrading androidbrowserhelper to 2.5.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-auth:21.3.0'
     implementation "androidx.credentials:credentials-play-services-auth:1.5.0"
     implementation "com.google.android.libraries.identity.googleid:googleid:1.1.1"
-    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.6.2'
+    implementation 'com.google.androidbrowserhelper:androidbrowserhelper:2.5.0'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"


### PR DESCRIPTION
This downgrades androidbrowserhelper back to 2.5.0 because 2.6.x versions require androidx.browser:browser:1.9.0-alpha04 which:

- requires SDK 36 (Capacitor v7 requires SDK 35)
- are alpha releases

Fixes #235

This partially reverts https://github.com/Cap-go/capacitor-social-login/commit/44d909f17662378a1646f523a7619df39c8958d3

Dependencies diff:

```diff
diff --git a/DEPS-7.9.0.md b/DEPS-7.9.0-fix.md
index 0e51f71..c2a35d2 100644
--- a/DEPS-7.9.0.md
+++ b/DEPS-7.9.0-fix.md
@@ -32,7 +32,7 @@ debugRuntimeClasspath - Resolved configuration for runtime for variant: debug
 |    |    |    +--- androidx.collection:collection:1.4.2 (*)
 |    |    |    +--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.2.0
 |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
-|    |    |    |    \--- com.google.guava:listenablefuture:1.0 -> 9999.0-empty-to-avoid-conflict-with-guava
+|    |    |    |    \--- com.google.guava:listenablefuture:1.0
 |    |    |    +--- androidx.interpolator:interpolator:1.0.0
 |    |    |    |    \--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
 |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2
@@ -73,7 +73,7 @@ debugRuntimeClasspath - Resolved configuration for runtime for variant: debug
 |    |    |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
 |    |    |    |    |    |    \--- androidx.tracing:tracing:1.0.0 -> 1.2.0
 |    |    |    |    |    |         \--- androidx.annotation:annotation:1.2.0 -> 1.8.1 (*)
-|    |    |    |    |    \--- com.google.guava:listenablefuture:1.0 -> 9999.0-empty-to-avoid-conflict-with-guava
+|    |    |    |    |    \--- com.google.guava:listenablefuture:1.0
 |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 -> 1.9.25 (*)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
 |    |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
@@ -271,16 +271,13 @@ debugRuntimeClasspath - Resolved configuration for runtime for variant: debug
      |         +--- androidx.appcompat:appcompat:1.1.0 -> 1.7.0 (*)
      |         +--- androidx.cardview:cardview:1.0.0
      |         |    \--- androidx.annotation:annotation:1.0.0 -> 1.8.1 (*)
-     |         +--- androidx.browser:browser:1.0.0 -> 1.9.0-alpha04
-     |         |    +--- androidx.activity:activity:1.9.0 -> 1.9.2 (*)
-     |         |    +--- androidx.annotation:annotation:1.8.1 (*)
-     |         |    +--- androidx.annotation:annotation-experimental:1.4.1 (*)
-     |         |    +--- androidx.collection:collection:1.4.2 (*)
+     |         +--- androidx.browser:browser:1.0.0 -> 1.4.0
+     |         |    +--- androidx.collection:collection:1.1.0 -> 1.4.2 (*)
      |         |    +--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.2.0 (*)
-     |         |    +--- androidx.core:core:1.10.0 -> 1.15.0 (*)
      |         |    +--- androidx.interpolator:interpolator:1.0.0 (*)
-     |         |    +--- com.google.guava:listenablefuture:1.0 -> 9999.0-empty-to-avoid-conflict-with-guava
-     |         |    \--- org.jspecify:jspecify:1.0.0
+     |         |    +--- androidx.core:core:1.1.0 -> 1.15.0 (*)
+     |         |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
+     |         |    \--- com.google.guava:listenablefuture:1.0
      |         +--- androidx.activity:activity:1.2.0 -> 1.9.2 (*)
      |         +--- androidx.fragment:fragment:1.3.0 -> 1.8.4 (*)
      |         +--- com.google.zxing:core:3.3.3
@@ -391,19 +388,10 @@ debugRuntimeClasspath - Resolved configuration for runtime for variant: debug
      |    +--- androidx.credentials:credentials:1.5.0 (c)
      |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.9.24 -> 1.9.25 (c)
      +--- com.google.android.libraries.identity.googleid:googleid:1.1.1 (*)
-     +--- com.google.androidbrowserhelper:androidbrowserhelper:2.6.2
-     |    +--- org.jetbrains.kotlin:kotlin-bom:1.8.22 -> 1.9.25 (*)
-     |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.7.3 (*)
+     +--- com.google.androidbrowserhelper:androidbrowserhelper:2.5.0
      |    +--- androidx.annotation:annotation:1.1.0 -> 1.8.1 (*)
      |    +--- androidx.core:core:1.0.2 -> 1.15.0 (*)
-     |    +--- androidx.appcompat:appcompat:1.7.0 (*)
-     |    +--- com.google.guava:guava:33.4.8-android
-     |    |    +--- com.google.guava:failureaccess:1.0.3
-     |    |    +--- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-     |    |    +--- org.jspecify:jspecify:1.0.0
-     |    |    +--- com.google.errorprone:error_prone_annotations:2.36.0
-     |    |    \--- com.google.j2objc:j2objc-annotations:3.0.0
-     |    \--- androidx.browser:browser:1.9.0-alpha04 (*)
+     |    \--- androidx.browser:browser:1.4.0 (*)
      \--- androidx.concurrent:concurrent-futures:1.2.0 (*)
 
 (c) - A dependency constraint, not a dependency. The dependency affected by the constraint occurs elsewhere in the tree.

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the Android browser helper library version.
  * No user-facing changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->