### PR TITLE
Mention iOSServerClientId is also needed for server side verification

### DIFF
--- a/MIGRATION_CODETRIX.md
+++ b/MIGRATION_CODETRIX.md
@@ -46,6 +46,9 @@ The plugin now uses exclusively the Web Client ID for authentication. You'll nee
 + });
 ```
 
+If you have `"serverClientId"` in your capacitor config, make sure you include it alongside `iOSClientId` as `iOSServerClientId`, too.
+It's required for offline mode or when you need to verify idToken on the server.
+
 ### Sign In
 ```diff
 - const user = await GoogleAuth.signIn();

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ await SocialLogin.initialize({
   google: {
     webClientId: 'YOUR_WEB_CLIENT_ID',        // Required for Android and Web
     iOSClientId: 'YOUR_IOS_CLIENT_ID',        // Required for iOS  
-    iOSServerClientId: 'YOUR_WEB_CLIENT_ID',  // Required for iOS offline mode (same as webClientId)
+    iOSServerClientId: 'YOUR_WEB_CLIENT_ID',  // Required for iOS offline mode and server authorization (same as webClientId)
     mode: 'online',  // 'online' or 'offline'
   }
 });
@@ -220,7 +220,7 @@ await SocialLogin.initialize({
 **Important Notes:**
 - `webClientId`: Required for Android and Web platforms
 - `iOSClientId`: Required for iOS platform  
-- `iOSServerClientId`: Required only when using `mode: 'offline'` on iOS (should be the same value as `webClientId`)
+- `iOSServerClientId`: Required when using `mode: 'offline'` on iOS or when you need to verify the token on the server (should be the same value as `webClientId`)
 - `mode: 'offline'`: Returns only `serverAuthCode` for backend authentication, no user profile data
 - `mode: 'online'`: Returns user profile data and access tokens (default)
 
@@ -686,7 +686,7 @@ Execute provider-specific calls
 
 Construct a type with a set of properties K of type T
 
-<code>{ [P in K]: T; }</code>
+<code>{ [P in K]: T; }</code>
 
 </docgen-api>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated migration guide to reflect the new social login plugin and revised sign-in flow.
  - Clarified Google configuration requirements: iOSServerClientId is required for iOS offline mode and when verifying tokens on a server (same value as webClientId).
  - Expanded Important Notes to cover server-side authorization scenarios.
  - Improved examples and streamlined formatting in code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->