### PR TITLE
fix facebook login setup docs

### DIFF
--- a/docs/setup_facebook.md
+++ b/docs/setup_facebook.md
@@ -140,9 +140,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the app was launched with a url. Feel free to add additional processing here,
         // but if you want the App API to support tracking app url opens, make sure to keep this call
         
-        var handled: Bool
-        
-        return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
         if (FBSDKCoreKit.ApplicationDelegate.shared.application(
             app,
             open: url,
@@ -153,8 +150,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         } else {
             return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
         }
-        
-        return ApplicationDelegateProxy.shared.application(app, open: url, options: options)
     }
 }
 ```


### PR DESCRIPTION
see 

https://developers.facebook.com/docs/facebook-login/android/#6--provide-the-development-and-release-key-hashes-for-your-app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Facebook setup guide for Android: corrected key-hash generation commands for debug and release keystores to produce the proper base64-encoded SHA-1 digest, ensuring valid key hashes for Facebook integration.
  * Clarified iOS AppDelegate URL-handling example in the docs so the Facebook SDK handler's result determines whether a URL is handled or delegated, improving accuracy of the integration example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->