### PR TITLE
fix: getPluginVersion placement

### DIFF
--- a/ios/Sources/SocialLoginPlugin/SocialLoginPlugin.swift
+++ b/ios/Sources/SocialLoginPlugin/SocialLoginPlugin.swift
@@ -25,6 +25,10 @@ public class SocialLoginPlugin: CAPPlugin, CAPBridgedPlugin {
     private let facebook = FacebookProvider()
     private let google = GoogleProvider()
 
+    @objc func getPluginVersion(_ call: CAPPluginCall) {
+        call.resolve(["version": self.PLUGIN_VERSION])
+    }
+
     @objc func initialize(_ call: CAPPluginCall) {
         var initialized = false
 
@@ -388,9 +392,4 @@ struct SocialLoginUser {
     let idToken: String?
     let refreshToken: String?
     let expiresIn: Int?
-
-    @objc func getPluginVersion(_ call: CAPPluginCall) {
-        call.resolve(["version": self.PLUGIN_VERSION])
-    }
-
 }


### PR DESCRIPTION
Fixes the placement of `getPluginVersion` by moving it to the correct block. This solves the problem introduced in 52cc03ccaceb05a9c680c032bf1f2852e4dba95d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized plugin version access to improve the SDK structure and simplify integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->