### PR TITLE
fix: getAuthorizationCode() for Facebook provider

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/social/login/FacebookProvider.java
+++ b/android/src/main/java/ee/forgr/capacitor/social/login/FacebookProvider.java
@@ -146,7 +146,7 @@ public class FacebookProvider implements SocialProvider {
     public void getAuthorizationCode(PluginCall call) {
         AccessToken accessToken = AccessToken.getCurrentAccessToken();
         if (accessToken != null && !accessToken.isExpired()) {
-            call.resolve(new JSObject().put("code", accessToken.getToken()));
+            call.resolve(new JSObject().put("accessToken", accessToken.getToken()));
         } else {
             call.reject("No valid access token found");
         }

--- a/ios/Sources/SocialLoginPlugin/FacebookProvider.swift
+++ b/ios/Sources/SocialLoginPlugin/FacebookProvider.swift
@@ -215,4 +215,18 @@ class FacebookProvider {
             }
         }
     }
+
+    func getAuthorizationCode(completion: @escaping (Result<(accessToken: String?, jwt: String?), Error>) -> Void) {
+        // First check if access token exists and is not expired
+        if let accessToken = AccessToken.current, !accessToken.isExpired {
+            // User is connected with access token, return it
+            completion(.success((accessToken: accessToken.tokenString, jwt: nil)))
+        } else if let authToken = AuthenticationToken.current, !authToken.tokenString.isEmpty {
+            // Access token not found but idToken (JWT) is available, return JWT
+            completion(.success((accessToken: nil, jwt: authToken.tokenString)))
+        } else {
+            // Neither access token nor idToken available
+            completion(.failure(NSError(domain: "FacebookProvider", code: 0, userInfo: [NSLocalizedDescriptionKey: "No Facebook authorization code available"])))
+        }
+    }
 }

--- a/ios/Sources/SocialLoginPlugin/SocialLoginPlugin.swift
+++ b/ios/Sources/SocialLoginPlugin/SocialLoginPlugin.swift
@@ -106,6 +106,23 @@ public class SocialLoginPlugin: CAPPlugin, CAPBridgedPlugin {
                 }
             }
         }
+        case "facebook": do {
+            self.facebook.getAuthorizationCode { res in
+                do {
+                    let result = try res.get()
+                    var response: [String: String] = [:]
+                    if let accessToken = result.accessToken {
+                        response["accessToken"] = accessToken
+                    }
+                    if let jwt = result.jwt {
+                        response["jwt"] = jwt
+                    }
+                    call.resolve(response)
+                } catch {
+                    call.reject(error.localizedDescription)
+                }
+            }
+        }
         default:
             call.reject("Invalid provider")
         }

--- a/src/facebook-provider.ts
+++ b/src/facebook-provider.ts
@@ -94,7 +94,7 @@ export class FacebookSocialLogin extends BaseSocialLogin {
     return new Promise((resolve, reject) => {
       FB.getLoginStatus((response) => {
         if (response.status === 'connected') {
-          resolve({ jwt: response.authResponse?.accessToken || '' });
+          resolve({ accessToken: response.authResponse?.accessToken || '' });
         } else {
           reject(new Error('No Facebook authorization code available'));
         }


### PR DESCRIPTION
Fixes https://github.com/Cap-go/capacitor-social-login/issues/279 by:

- Adding getAuthorizationCode() for iOS for Facebook (either `accessToken` or `jwt` depending on limited login)
- Renaming the `code` to `accessToken` for Android for Facebook
- Correctly naming the access token on the web for facebook. JWT only happens for iOS limited login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected Facebook authorization token handling across all platforms. The authentication provider now returns access tokens instead of authorization codes during the authorization flow. Changes have been consistently implemented on Android, iOS, and web platforms to ensure unified behavior and improved token management for all Facebook-authenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->