### PR TITLE
fix: correctly close the sub-window when user doesn't consent during GSI consent step

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -36,13 +36,24 @@ export class SocialLoginWeb extends WebPlugin implements SocialLoginPlugin {
       console.log('OAUTH_STATE_KEY found');
       const result = this.handleOAuthRedirect();
       if (result) {
-        window.opener?.postMessage(
-          {
-            type: 'oauth-response',
-            ...result.result,
-          },
-          window.location.origin,
-        );
+        // Check if it's an error result
+        if ('error' in result) {
+          window.opener?.postMessage(
+            {
+              type: 'oauth-error',
+              error: result.error,
+            },
+            window.location.origin,
+          );
+        } else {
+          window.opener?.postMessage(
+            {
+              type: 'oauth-response',
+              ...result.result,
+            },
+            window.location.origin,
+          );
+        }
         window.close();
       }
     }


### PR DESCRIPTION
Fixes #281.

Now, when the user clicks this button, it will close the popout correctly

<img width="1056" height="1376" alt="image" src="https://github.com/user-attachments/assets/6cf9361a-b8f7-49be-ad69-3fbc5846b9b8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced OAuth error handling with improved detection and reporting of authentication failures
* Added proper cleanup and timeout management for authentication flows
* Better distinction between successful and failed authentication attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->