### PR TITLE
fix: pass authorizationCode in iOS

### DIFF
--- a/ios/Sources/SocialLoginPlugin/SocialLoginPlugin.swift
+++ b/ios/Sources/SocialLoginPlugin/SocialLoginPlugin.swift
@@ -599,11 +599,15 @@ public class SocialLoginPlugin: CAPPlugin, CAPBridgedPlugin {
                     "familyName": appleResponse.profile.familyName ?? ""
                 ]
 
-                let appleResult: [String: Any] = [
+                var appleResult: [String: Any] = [
                     "accessToken": accessTokenObject ?? NSNull(),
                     "profile": profileObject,
                     "idToken": appleResponse.idToken ?? ""
                 ]
+                
+                if let authorizationCode = appleResponse.authorizationCode {
+                    appleResult["authorizationCode"] = authorizationCode
+                }
 
                 call.resolve([
                     "provider": "apple",


### PR DESCRIPTION
### Business reasoning

I have decided to fix #296 as I thought it would be simple to do. It improves Apple login on iOS

### The fix

The value was correctly passed in `AppleProviderResponse`, but it did not get correctly passed down to JS. This PR fixes that

<img width="3444" height="220" alt="image" src="https://github.com/user-attachments/assets/83854c19-babc-4b35-9491-4fbd231f3269" />

### Lint

Lint was skipped for this PR, as swiftlint is still broken


### Docs

I don't believe the `useProperTokenExchange` is documented anywhere. Documentation for  `useProperTokenExchange` shall be done in a different PR

Fixes #296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple Sign-In to properly capture and include authorization codes in authentication responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->