### PR TITLE
fix(android): add consumer ProGuard rules for minification support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-proguard-rules.pro'
         }
     }
     lintOptions {

--- a/android/consumer-proguard-rules.pro
+++ b/android/consumer-proguard-rules.pro
@@ -1,0 +1,36 @@
+# Consumer ProGuard rules for @capgo/capacitor-social-login
+# These rules are automatically applied to apps that depend on this library
+
+# Keep all plugin classes and their members
+-keep class ee.forgr.capacitor.social.login.** { *; }
+-keepclassmembers class ee.forgr.capacitor.social.login.** { *; }
+
+# Keep inner classes (critical for OAuth2Provider config and token storage)
+-keep class ee.forgr.capacitor.social.login.**$* { *; }
+
+# Keep Activities for Intent resolution
+-keep class ee.forgr.capacitor.social.login.*Activity { *; }
+
+# Capacitor integration
+-keep class com.getcapacitor.** { *; }
+-keepclassmembers class com.getcapacitor.** { *; }
+
+# OkHttp (used for OAuth2/Twitter token endpoints)
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-keep class okhttp3.** { *; }
+-keep interface okhttp3.** { *; }
+
+# JWT Decode library (used for Apple Sign-In)
+-keep class com.auth0.android.jwt.** { *; }
+
+# Google Sign-In (if included)
+-keep class com.google.android.gms.auth.** { *; }
+-keep class com.google.android.libraries.identity.googleid.** { *; }
+-keep class androidx.credentials.** { *; }
+
+# Facebook SDK (if included)
+-keep class com.facebook.** { *; }
+
+# CustomTabs for Apple Sign-In
+-keep class androidx.browser.customtabs.** { *; }


### PR DESCRIPTION
## Summary
Adds consumer ProGuard rules to fix minification breaking the app. When consuming apps enable `minifyEnabled=true`, R8 now automatically preserves plugin classes, inner classes, and critical dependencies (OkHttp, JWT, Google Sign-In, Facebook, etc.).

## Problem
Customers upgrading to v8.2.5+ report that enabling `minifyEnabled=true` in their build.gradle breaks the app, while it works fine with minification disabled or on v7.19.1.

## Solution
Creates `consumer-proguard-rules.pro` that is automatically applied to dependent apps, preserving OAuth2Provider inner classes, JSON field names, reflection-based class loading, and all social provider dependencies.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Android build configuration to ensure plugin functionality is properly preserved in release builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->