### PR TITLE
fix: Address code review feedback for OAuth popup handling

### DIFF
--- a/src/google-provider.ts
+++ b/src/google-provider.ts
@@ -357,7 +357,7 @@ export class GoogleSocialLogin extends BaseSocialLogin {
     const top = window.screenY + (window.outerHeight - height) / 2;
     localStorage.setItem(
       BaseSocialLogin.OAUTH_STATE_KEY,
-      JSON.stringify({ provider: 'google', loginType: this.loginType }),
+      JSON.stringify({ provider: 'google', loginType: this.loginType, nonce }),
     );
     const popup = window.open(url, 'Google Sign In', `width=${width},height=${height},left=${left},top=${top},popup=1`);
 
@@ -414,9 +414,15 @@ export class GoogleSocialLogin extends BaseSocialLogin {
                 responseType: 'online',
               },
             });
+          } else {
+            reject(new Error('Invalid OAuth response: missing accessToken or idToken'));
           }
         } else {
           const { serverAuthCode } = data as { serverAuthCode: string };
+          if (!serverAuthCode) {
+            reject(new Error('Invalid OAuth response: missing serverAuthCode'));
+            return;
+          }
           resolve({
             provider: 'google' as T,
             result: {

--- a/src/twitter-provider.ts
+++ b/src/twitter-provider.ts
@@ -148,8 +148,13 @@ export class TwitterSocialLogin extends BaseSocialLogin {
           }
           cleanup(messageHandler, timeoutHandle, popupClosedInterval);
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { provider: _ignoredProvider, ...payload } = data as unknown as TwitterLoginResponse & {
+          const {
+            provider: _ignoredProvider,
+            type: _ignoredType,
+            ...payload
+          } = data as unknown as TwitterLoginResponse & {
             provider?: string;
+            type?: string;
           };
           resolve({
             provider: 'twitter' as T,


### PR DESCRIPTION
## Summary
Follow-up fixes from code review on PR #313:

- Fix Google provider hanging promise when tokens missing by rejecting with error
- Fix Twitter provider payload extraction to remove 'type' field consistently  
- Add Google BroadcastChannel support by storing nonce in OAUTH_STATE_KEY

## Test plan
- Verify Google OAuth works in both online and offline modes
- Test Twitter OAuth flow with BroadcastChannel fallback
- Confirm error handling when OAuth response is malformed

🤖 Generated with [Claude Code](https://claude.com/claude-code)