### PR TITLE
fix: changed consumerProguardFiles position for capacitor-social-login (fixes #306)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,12 +30,12 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles 'consumer-proguard-rules.pro'
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            consumerProguardFiles 'consumer-proguard-rules.pro'
         }
     }
     lintOptions {


### PR DESCRIPTION
There’s a small problem: consumerProguardFiles was inside the release block instead of defaultConfig.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Android build configuration settings to improve compatibility with consuming applications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->