### PR TITLE
fix(ios): fix additionalTokenParameters never applied and broken form encoding

### DIFF
--- a/ios/Sources/SocialLoginPlugin/OAuth2Provider.swift
+++ b/ios/Sources/SocialLoginPlugin/OAuth2Provider.swift
@@ -113,14 +113,14 @@ class OAuth2Provider: NSObject {
                 responseType: config["responseType"] as? String ?? "code",
                 pkceEnabled: config["pkceEnabled"] as? Bool ?? true,
                 scope: normalizeScope(config["scope"] ?? config["scopes"]),
-                additionalParameters: (config["additionalParameters"] as? [String: Any]).map { $0.compactMapValues { $0 as? String } },
+                additionalParameters: (config["additionalParameters"] as? [String: Any]).map { $0.mapValues { "\($0)" } },
                 loginHint: config["loginHint"] as? String,
                 prompt: config["prompt"] as? String,
-                additionalTokenParameters: (config["additionalTokenParameters"] as? [String: Any]).map { $0.compactMapValues { $0 as? String } },
-                additionalResourceHeaders: (config["additionalResourceHeaders"] as? [String: Any]).map { $0.compactMapValues { $0 as? String } },
+                additionalTokenParameters: (config["additionalTokenParameters"] as? [String: Any]).map { $0.mapValues { "\($0)" } },
+                additionalResourceHeaders: (config["additionalResourceHeaders"] as? [String: Any]).map { $0.mapValues { "\($0)" } },
                 logoutUrl: (config["logoutUrl"] as? String) ?? (config["endSessionEndpoint"] as? String),
                 postLogoutRedirectUrl: config["postLogoutRedirectUrl"] as? String,
-                additionalLogoutParameters: (config["additionalLogoutParameters"] as? [String: Any]).map { $0.compactMapValues { $0 as? String } },
+                additionalLogoutParameters: (config["additionalLogoutParameters"] as? [String: Any]).map { $0.mapValues { "\($0)" } },
                 iosPrefersEphemeralWebBrowserSession:
                     (config["iosPrefersEphemeralWebBrowserSession"] as? Bool) ??
                     (config["iosPrefersEphemeralSession"] as? Bool) ??
@@ -228,7 +228,7 @@ class OAuth2Provider: NSObject {
                 let state = payload["state"] as? String ?? UUID().uuidString
                 let codeVerifier = payload["codeVerifier"] as? String ?? self.generateCodeVerifier()
                 let redirect = payload["redirectUrl"] as? String ?? config.redirectUrl
-                let additionalLoginParams = payload["additionalParameters"] as? [String: String]
+                let additionalLoginParams = (payload["additionalParameters"] as? [String: Any]).map { $0.mapValues { "\($0)" } }
 
                 self.currentState = state
                 self.currentCodeVerifier = codeVerifier
@@ -741,7 +741,7 @@ extension OAuth2Provider: ASWebAuthenticationPresentationContextProviding {
 private extension Dictionary where Key == String, Value == String {
     func percentEncoded() -> Data? {
         var formValueAllowed = CharacterSet.urlQueryAllowed
-        formValueAllowed.remove(charactersIn: "+&=")
+        formValueAllowed.remove(charactersIn: "+&=/")
         return map { key, value in
             "\(key.addingPercentEncoding(withAllowedCharacters: formValueAllowed) ?? key)=\(value.addingPercentEncoding(withAllowedCharacters: formValueAllowed) ?? value)"
         }


### PR DESCRIPTION
## Summary

   Fixes #357

   Two bugs in `OAuth2Provider.swift` that together made `additionalTokenParameters` (and `additionalParameters`,
   `additionalResourceHeaders`, `additionalLogoutParameters`) completely non-functional on iOS, causing OAuth2 providers
    that require a `client_secret` in the token exchange (e.g. LinkedIn) to always fail with `invalid_client`.

   ---

   ### Bug 1 — Silent `nil` cast for `[String: Any]` dictionaries (lines 116, 119, 120, 123)

   The Capacitor JS bridge always delivers nested dictionaries as `[String: Any]`, never `[String: String]`. The
   previous `as? [String: String]` conditional cast therefore silently returned `nil` 100% of the time.

   **Fix:** cast to `[String: Any]` first, then use `compactMapValues { $0 as? String }` — the same pattern already used
    in `SocialLoginPlugin.swift`'s `refreshToken` method.

   ```swift
   // Before
   additionalTokenParameters: config["additionalTokenParameters"] as? [String: String],

   // After
   additionalTokenParameters: (config["additionalTokenParameters"] as? [String: Any]).map { $0.compactMapValues { $0 as?
    String } },
   ```

   ---

   ### Bug 2 — `percentEncoded()` does not encode `+` and `=` (line ~742)

   Swift's `.urlQueryAllowed` character set includes `+` and `=`. In `application/x-www-form-urlencoded`, `+` decodes as
    a space and `=` is the key/value separator, so any `client_secret` containing those characters (common in
   base64-encoded secrets, e.g. `WPL_AP1...EseZ+A==`) was silently corrupted before reaching the server.

   **Fix:** remove `+`, `&`, and `=` from the allowed set before encoding.

   ```swift
   // Before
   value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)

   // After
   var formValueAllowed = CharacterSet.urlQueryAllowed
   formValueAllowed.remove(charactersIn: "+&=")
   value.addingPercentEncoding(withAllowedCharacters: formValueAllowed)
   ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth2 parameter handling to accept a wider range of provider and per-login parameter formats and reliably merge base and per-login settings for successful logins.
  * Strengthened URL/form value encoding to exclude problematic characters, improving security and reliability of token and request encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->