### PR TITLE
Clarify Google offline refresh behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ await SocialLogin.initialize({
 - `webClientId`: Required for Android and Web platforms
 - `iOSClientId`: Required for iOS platform  
 - `iOSServerClientId`: Required when using `mode: 'offline'` on iOS or when you need to verify the token on the server (should be the same value as `webClientId`)
-- `mode: 'offline'`: Returns only `serverAuthCode` for backend authentication, no user profile data
+- `mode: 'offline'`: Returns only `serverAuthCode` for backend authentication, no user profile data, and `refresh()` is not available in-app. Exchange `serverAuthCode` on your backend and refresh there.
 - `mode: 'online'`: Returns user profile data and access tokens (default)
 
 ### Android configuration
@@ -438,6 +438,8 @@ When using `mode: 'offline'`, the login response will only contain:
   // Note: No user profile data is returned in offline mode
 }
 ```
+
+`serverAuthCode` is for your backend. In offline mode you should exchange it on your server for access and refresh tokens, then refresh those tokens on the server side. Calling `SocialLogin.refresh({ provider: 'google' ... })` is not supported in offline mode.
 
 ### Web
 

--- a/README.md
+++ b/README.md
@@ -445,6 +445,8 @@ When using `mode: 'offline'`, the login response will only contain:
 
 Initialize method to create a script tag with Google lib. We cannot know when it's ready so be sure to do it early in web otherwise it will fail.
 
+On Web, Google `refresh()` is not implemented, even when using `mode: 'online'`. Call `SocialLogin.login({ provider: 'google', ... })` again to obtain a fresh token.
+
 ## OAuth2 (Generic)
 
 The plugin supports generic OAuth2 authentication, allowing you to integrate with any OAuth2-compliant provider (GitHub, Azure AD, Auth0, Okta, custom servers, etc.). You can configure multiple OAuth2 providers simultaneously.

--- a/android/src/main/java/ee/forgr/capacitor/social/login/GoogleProvider.java
+++ b/android/src/main/java/ee/forgr/capacitor/social/login/GoogleProvider.java
@@ -58,6 +58,8 @@ public class GoogleProvider implements SocialProvider {
     private static final String GOOGLE_DATA_PREFERENCE = "GOOGLE_LOGIN_GOOGLE_DATA_9158025e-947d-4211-ba51-40451630cc47";
     private static final Integer FUTURE_LIST_LENGTH = 128;
     private static final String TOKEN_REQUEST_URL = "https://www.googleapis.com/oauth2/v3/tokeninfo";
+    private static final String OFFLINE_REFRESH_NOT_SUPPORTED_MESSAGE =
+        "Google refresh() is not available when using offline mode. Offline mode only returns serverAuthCode for backend token exchange. Send serverAuthCode to your backend and refresh tokens there, or switch google.mode to 'online' for client-side refresh.";
     private static final String[] DEFAULT_SCOPES = new String[] {
         "https://www.googleapis.com/auth/userinfo.email",
         "https://www.googleapis.com/auth/userinfo.profile",
@@ -871,7 +873,8 @@ public class GoogleProvider implements SocialProvider {
     @Override
     public void refresh(PluginCall call) {
         if (this.mode == GoogleProviderLoginType.OFFLINE) {
-            call.reject("refresh is not implemented when using offline mode");
+            Log.w(LOG_TAG, OFFLINE_REFRESH_NOT_SUPPORTED_MESSAGE);
+            call.reject(OFFLINE_REFRESH_NOT_SUPPORTED_MESSAGE);
             return;
         }
         if (this.clientId == null || this.clientId.isEmpty()) {

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "@capgo/capacitor-social-login",
+      "dependencies": {
+        "tslib": "^2.8.1",
+      },
       "devDependencies": {
         "@capacitor/android": "^8.0.0",
         "@capacitor/docgen": "^0.3.1",
@@ -11,6 +14,7 @@
         "@ionic/eslint-config": "^0.4.0",
         "@ionic/prettier-config": "^4.0.0",
         "@ionic/swiftlint-config": "^2.0.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/google.accounts": "^0.0.18",
         "@types/node": "^24.10.1",
         "eslint": "^8.57.1",
@@ -95,6 +99,10 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@rollup/plugin-node-resolve": ["@rollup/plugin-node-resolve@16.0.3", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "@types/resolve": "1.20.2", "deepmerge": "^4.2.2", "is-module": "^1.0.0", "resolve": "^1.22.1" }, "peerDependencies": { "rollup": "^2.78.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
+
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.54.0", "", { "os": "android", "cpu": "arm" }, "sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng=="],
 
     "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.54.0", "", { "os": "android", "cpu": "arm64" }, "sha512-Skx39Uv+u7H224Af+bDgNinitlmHyQX1K/atIA32JP3JQw6hVODX5tkbi2zof/E69M1qH2UoN3Xdxgs90mmNYw=="],
@@ -152,6 +160,8 @@
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
 
     "@types/node": ["@types/node@24.10.4", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg=="],
+
+    "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
@@ -251,6 +261,8 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
@@ -306,6 +318,8 @@
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
@@ -424,6 +438,8 @@
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
+
+    "is-module": ["is-module@1.0.0", "", {}, "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="],
 
     "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
 
@@ -549,7 +565,7 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -712,6 +728,8 @@
     "flat-cache/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
     "glob/minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "tsutils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 

--- a/ios/Sources/SocialLoginPlugin/GoogleProvider.swift
+++ b/ios/Sources/SocialLoginPlugin/GoogleProvider.swift
@@ -16,6 +16,7 @@ class GoogleProvider {
     var additionalScopes: [String]!
     var defaultGrantedScopes = ["email", "profile", "openid"]
     var mode = GoogleProviderLoginType.ONLINE
+    private let offlineRefreshNotSupportedMessage = "Google refresh() is not available when using offline mode. Offline mode only returns serverAuthCode for backend token exchange. Send serverAuthCode to your backend and refresh tokens there, or switch google.mode to 'online' for client-side refresh."
 
     func initialize(clientId: String, mode: GoogleProviderLoginType, serverClientId: String? = nil, hostedDomain: String? = nil) {
         configuration = GIDConfiguration(clientID: clientId, serverClientID: serverClientId, hostedDomain: hostedDomain, openIDRealm: nil)
@@ -194,6 +195,11 @@ class GoogleProvider {
     }
 
     func refresh(completion: @escaping (Result<Void, Error>) -> Void) {
+        if self.mode == .OFFLINE {
+            print("[GoogleProvider] \(offlineRefreshNotSupportedMessage)")
+            completion(.failure(NSError(domain: "GoogleProvider", code: 0, userInfo: [NSLocalizedDescriptionKey: offlineRefreshNotSupportedMessage])))
+            return
+        }
         DispatchQueue.main.async {
             guard let currentUser = GIDSignIn.sharedInstance.currentUser else {
                 completion(.failure(NSError(domain: "GoogleProvider", code: 0, userInfo: [NSLocalizedDescriptionKey: "User not logged in"])))

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -241,7 +241,9 @@ export interface InitializeOptions {
      *   - `logout()` - Will reject with "not implemented when using offline mode"
      *   - `isLoggedIn()` - Will reject with "not implemented when using offline mode"
      *   - `getAuthorizationCode()` - Will reject with "not implemented when using offline mode"
+     *   - `refresh()` - Will reject because offline mode only returns `serverAuthCode`; token refresh must happen on your backend
      * - Only `login()` method works in offline mode, returning serverAuthCode only
+     * - `serverAuthCode` must be exchanged on your backend for access/refresh tokens
      * - Requires `iOSServerClientId` to be set on iOS
      *
      * @example 'offline'
@@ -942,7 +944,9 @@ export interface SocialLoginPlugin {
    *
    * **Google Offline Mode Limitation:**
    * This method is NOT supported when Google is initialized with `mode: 'offline'`.
-   * It will reject with error: "refresh is not implemented when using offline mode"
+   * Offline mode only returns `serverAuthCode` for backend token exchange, so token refresh must happen on your backend.
+   * The plugin logs and rejects with a message explaining that you should send `serverAuthCode` to your backend,
+   * refresh the Google tokens there, or switch to `mode: 'online'` for client-side refresh.
    *
    * @throws Error if Google provider is in offline mode
    */

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -952,7 +952,7 @@ export interface SocialLoginPlugin {
    * On Web, Google `refresh()` is not implemented, even when using `mode: 'online'`.
    * Call `login()` again on Web to obtain a fresh token instead.
    *
-   * @throws Error if Google provider is in offline mode
+   * @throws Error if Google provider is in offline mode, or on Web where Google `refresh()` is not implemented
    */
   refresh(options: LoginOptions): Promise<void>;
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -948,6 +948,10 @@ export interface SocialLoginPlugin {
    * The plugin logs and rejects with a message explaining that you should send `serverAuthCode` to your backend,
    * refresh the Google tokens there, or switch to `mode: 'online'` for client-side refresh.
    *
+   * **Google Web Limitation:**
+   * On Web, Google `refresh()` is not implemented, even when using `mode: 'online'`.
+   * Call `login()` again on Web to obtain a fresh token instead.
+   *
    * @throws Error if Google provider is in offline mode
    */
   refresh(options: LoginOptions): Promise<void>;

--- a/src/google-provider.ts
+++ b/src/google-provider.ts
@@ -1,6 +1,9 @@
 import { BaseSocialLogin } from './base';
 import type { GoogleLoginOptions, LoginResult, ProviderResponseMap, AuthorizationCode } from './definitions';
 
+const GOOGLE_OFFLINE_REFRESH_MESSAGE =
+  "Google refresh() is not available when using offline mode. Offline mode only returns serverAuthCode for backend token exchange. Send serverAuthCode to your backend and refresh tokens there, or switch google.mode to 'online' for client-side refresh.";
+
 export class GoogleSocialLogin extends BaseSocialLogin {
   private clientId: string | null = null;
   private hostedDomain?: string;
@@ -125,8 +128,13 @@ export class GoogleSocialLogin extends BaseSocialLogin {
   }
 
   async refresh(): Promise<void> {
-    // For Google, we can prompt for re-authentication
-    return Promise.reject('Not implemented');
+    if (this.loginType === 'offline') {
+      console.warn(`[SocialLogin] ${GOOGLE_OFFLINE_REFRESH_MESSAGE}`);
+      return Promise.reject(new Error(GOOGLE_OFFLINE_REFRESH_MESSAGE));
+    }
+    return Promise.reject(
+      new Error('Google refresh is not implemented on web. Use login() again to obtain a new token.'),
+    );
   }
 
   handleOAuthRedirect(url: URL): LoginResult | { error: string } | null {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { SocialLoginBase } from './social-login';
+import { SocialLogin, SocialLoginBase } from './social-login';
 
 export * from './definitions';
 export * from './auth-connect';
-export { SocialLoginBase as SocialLogin };
+export { SocialLogin, SocialLoginBase };

--- a/src/social-login.ts
+++ b/src/social-login.ts
@@ -26,6 +26,11 @@ const rawSocialLogin = registerPlugin<SocialLoginPlugin>('SocialLogin', {
 class SocialLoginClient implements SocialLoginPlugin {
   private initializeOptions?: InitializeOptions;
 
+  constructor() {
+    this.initialize = this.initialize.bind(this);
+    this.refresh = this.refresh.bind(this);
+  }
+
   async initialize(options: InitializeOptions): Promise<void> {
     this.initializeOptions = options;
     return rawSocialLogin.initialize(options);

--- a/src/social-login.ts
+++ b/src/social-login.ts
@@ -32,8 +32,8 @@ class SocialLoginClient implements SocialLoginPlugin {
   }
 
   async initialize(options: InitializeOptions): Promise<void> {
+    await rawSocialLogin.initialize(options);
     this.initializeOptions = options;
-    return rawSocialLogin.initialize(options);
   }
 
   async login<T extends LoginOptions['provider']>(

--- a/src/social-login.ts
+++ b/src/social-login.ts
@@ -13,6 +13,7 @@ import type {
   ProviderSpecificCallOptionsMap,
   ProviderSpecificCallResponseMap,
   SocialLoginPlugin,
+  isLoggedInOptions,
 } from './definitions';
 
 const GOOGLE_OFFLINE_REFRESH_MESSAGE =
@@ -43,9 +44,7 @@ class SocialLoginClient implements SocialLoginPlugin {
     return rawSocialLogin.logout(options);
   }
 
-  async isLoggedIn(options: { provider: 'apple' | 'google' | 'facebook' | 'twitter' | 'oauth2' }): Promise<{
-    isLoggedIn: boolean;
-  }> {
+  async isLoggedIn(options: isLoggedInOptions): Promise<{ isLoggedIn: boolean }> {
     return rawSocialLogin.isLoggedIn(options);
   }
 

--- a/src/social-login.ts
+++ b/src/social-login.ts
@@ -1,7 +1,113 @@
 import { registerPlugin } from '@capacitor/core';
 
-import type { SocialLoginPlugin } from './definitions';
+import type {
+  AuthorizationCode,
+  AuthorizationCodeOptions,
+  InitializeOptions,
+  LoginOptions,
+  OpenSecureWindowOptions,
+  OpenSecureWindowResponse,
+  OAuth2LoginResponse,
+  ProviderResponseMap,
+  ProviderSpecificCall,
+  ProviderSpecificCallOptionsMap,
+  ProviderSpecificCallResponseMap,
+  SocialLoginPlugin,
+} from './definitions';
 
-export const SocialLoginBase = registerPlugin<SocialLoginPlugin>('SocialLogin', {
+const GOOGLE_OFFLINE_REFRESH_MESSAGE =
+  "Google refresh() is not available when using offline mode. Offline mode only returns serverAuthCode for backend token exchange. Send serverAuthCode to your backend and refresh tokens there, or switch google.mode to 'online' for client-side refresh.";
+
+const rawSocialLogin = registerPlugin<SocialLoginPlugin>('SocialLogin', {
   web: () => import('./web').then((m) => new m.SocialLoginWeb()),
 });
+
+class SocialLoginClient implements SocialLoginPlugin {
+  private initializeOptions?: InitializeOptions;
+
+  async initialize(options: InitializeOptions): Promise<void> {
+    this.initializeOptions = options;
+    return rawSocialLogin.initialize(options);
+  }
+
+  async login<T extends LoginOptions['provider']>(
+    options: Extract<LoginOptions, { provider: T }>,
+  ): Promise<{ provider: T; result: ProviderResponseMap[T] }> {
+    return rawSocialLogin.login(options);
+  }
+
+  async logout(options: {
+    provider: 'apple' | 'google' | 'facebook' | 'twitter' | 'oauth2';
+    providerId?: string;
+  }): Promise<void> {
+    return rawSocialLogin.logout(options);
+  }
+
+  async isLoggedIn(options: { provider: 'apple' | 'google' | 'facebook' | 'twitter' | 'oauth2' }): Promise<{
+    isLoggedIn: boolean;
+  }> {
+    return rawSocialLogin.isLoggedIn(options);
+  }
+
+  async getAuthorizationCode(options: AuthorizationCodeOptions): Promise<AuthorizationCode> {
+    return rawSocialLogin.getAuthorizationCode(options);
+  }
+
+  async refresh(options: LoginOptions): Promise<void> {
+    if (options.provider === 'google' && this.initializeOptions?.google?.mode === 'offline') {
+      console.warn(`[SocialLogin] ${GOOGLE_OFFLINE_REFRESH_MESSAGE}`);
+    }
+    return rawSocialLogin.refresh(options);
+  }
+
+  async refreshToken(options: {
+    provider: 'oauth2';
+    providerId: string;
+    refreshToken?: string;
+    additionalParameters?: Record<string, string>;
+  }): Promise<OAuth2LoginResponse> {
+    return rawSocialLogin.refreshToken(options);
+  }
+
+  async handleRedirectCallback() {
+    return rawSocialLogin.handleRedirectCallback();
+  }
+
+  async decodeIdToken(options: { idToken?: string; token?: string }): Promise<{ claims: Record<string, any> }> {
+    return rawSocialLogin.decodeIdToken(options);
+  }
+
+  async getAccessTokenExpirationDate(options: { accessTokenExpirationDate: number }): Promise<{ date: string }> {
+    return rawSocialLogin.getAccessTokenExpirationDate(options);
+  }
+
+  async isAccessTokenAvailable(options: { accessToken: string | null }): Promise<{ isAvailable: boolean }> {
+    return rawSocialLogin.isAccessTokenAvailable(options);
+  }
+
+  async isAccessTokenExpired(options: { accessTokenExpirationDate: number }): Promise<{ isExpired: boolean }> {
+    return rawSocialLogin.isAccessTokenExpired(options);
+  }
+
+  async isRefreshTokenAvailable(options: { refreshToken: string | null }): Promise<{ isAvailable: boolean }> {
+    return rawSocialLogin.isRefreshTokenAvailable(options);
+  }
+
+  async providerSpecificCall<T extends ProviderSpecificCall>(options: {
+    call: T;
+    options: ProviderSpecificCallOptionsMap[T];
+  }): Promise<ProviderSpecificCallResponseMap[T]> {
+    return rawSocialLogin.providerSpecificCall(options);
+  }
+
+  async getPluginVersion(): Promise<{ version: string }> {
+    return rawSocialLogin.getPluginVersion();
+  }
+
+  async openSecureWindow(options: OpenSecureWindowOptions): Promise<OpenSecureWindowResponse> {
+    return rawSocialLogin.openSecureWindow(options);
+  }
+}
+
+export const SocialLoginBase = rawSocialLogin;
+export const SocialLogin = new SocialLoginClient();


### PR DESCRIPTION
## What
- add explicit JS and native logging/rejection messages when `refresh()` is called for Google `mode: 'offline'`
- make iOS match the documented offline limitation by rejecting `refresh()` in offline mode
- clarify the offline-mode limitation in `src/definitions.ts` so generated docs and README state that refresh must happen on the backend
- regenerate README/docgen output and sync the Bun lockfile to the declared dependencies

## Why
- users keep reading the existing docs as if Android Google refresh is generally available after PR #340
- in practice, `refresh()` only makes sense for Google `mode: 'online'`; offline mode only returns `serverAuthCode` for backend token exchange
- when the plugin just says "not implemented", users infer a missing feature instead of a backend-only flow

## How
- wrap the exported JS client so `refresh()` can warn before delegating to native
- replace the Android/iOS/web offline refresh errors with a specific guidance message pointing users to backend exchange or `mode: 'online'`
- update the Google offline JSDoc so docgen surfaces the limitation in generated API docs
- rebuild the generated docs artifacts with Bun
- AI-assisted with Codex

## Testing
- `bun run fmt`
- `bun run verify`

## Not Tested
- manual runtime verification inside a sample app for each platform


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Google offline/online behavior: refresh is unavailable in offline mode (exchange serverAuthCode on backend); noted that on Web refresh() is not implemented—even in online mode—so call login() again to get a fresh token.

* **Bug Fixes**
  * Standardized and clarified messages/warnings when attempting Google refresh in offline mode across platforms.

* **Refactor**
  * Reworked plugin exports and introduced a client wrapper to centralize initialization state and surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->