### PR TITLE
docs(android): clarify Google Credential Manager setup for #422

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,26 +420,80 @@ const res = await SocialLogin.login({
 });
 ```
 
-#### Android troubleshooting (SHA-1 and Firebase)
+#### Android troubleshooting (Credential Manager, SHA-1, and Firebase)
 
-Many Android "auth 10/16" or blank-response issues come from a mismatched SHA-1 fingerprint. Use the exact build you install on the device to register the SHA-1 in Google Cloud/Firebase:
+On Android this plugin uses **Google Credential Manager** (`androidx.credentials` + Sign in with Google), not the legacy `GoogleSignInClient` API. Logcat errors such as `GetCredentialCustomException: [28444] Developer console is not set up correctly` come from that stack.
 
-1. Build a signed APK from Android Studio (`Build` → `Generate Signed App Bundle / APK`, pick APK) using your release keystore.
-2. Extract the SHA-1 from that final APK:
-   ```bash
-   keytool -printcert -jarfile android/app/release/app-release.apk
-   ```
-3. Add that SHA-1 to your Android OAuth client in [Google Cloud Console](https://console.cloud.google.com/apis/credentials) (package name + SHA-1).
-4. Reinstall the same signed APK on device for testing:
-   ```bash
-   adb install android/app/release/app-release.apk
-   ```
-5. When consuming the plugin result, read tokens from `result.result`:
-   ```ts
-   const login = await SocialLogin.login({ provider: 'google' });
-   const idToken = login.result?.idToken; // not login.idToken
-   ```
-   For Firebase Auth, create credentials with that `idToken` (and use the Web Client ID as `webClientId` in `initialize`).
+Filter Logcat with `GoogleProvider` or `CapgoSocialLogin` after a failed login. The plugin logs your **package name**, **signing SHA-1**, and a masked **webClientId** to help compare against Google Cloud Console.
+
+##### Required Google Cloud setup (all in the same project)
+
+You need **two kinds** of OAuth 2.0 client IDs:
+
+| Client type | Used for | Where it goes |
+|-------------|----------|---------------|
+| **Web application** | Server / ID token audience | `webClientId` in `SocialLogin.initialize()` |
+| **Android** (one per signing key) | Proves your APK is allowed to call Google | Google Cloud Console only — **do not** pass this ID to `webClientId` |
+
+Common mistake: using the **Android** client ID as `webClientId`. Credential Manager requires the **Web** client ID there. The Android client only needs the correct **package name + SHA-1** registered in the console.
+
+Create one Android OAuth client for **each** certificate that signs builds you test:
+
+- **Debug** — from `./gradlew signingReport` (debug variant)
+- **Release** — from the APK/AAB you actually install (see below)
+- **Play App Signing** — from Play Console → **App integrity** → **App signing key certificate** (required for Play Store builds even if your upload key SHA-1 is already registered)
+
+The `applicationId` in `android/app/build.gradle` must match the Android OAuth client package name exactly (including any `.debug` suffix if you use one).
+
+If the OAuth consent screen is in **Testing** mode, add every Google account you test with under **Audience → Test users**. Publishing the app to Production is **not** required for `email` / `profile` scopes. **Digital Asset Links** (`assetlinks.json`) are **not** required for Sign in with Google via Credential Manager.
+
+Google Cloud changes can take **up to a few hours** to propagate; a device restart alone may not be enough.
+
+##### Error `[28444] Developer console is not set up correctly`
+
+This almost always means Google rejected the combination of **installed APK signing certificate**, **package name**, and **webClientId`. Work through this checklist:
+
+1. Confirm `webClientId` is the **Web application** client ID (ends with `.apps.googleusercontent.com`).
+2. Run the app, reproduce the failure, and read Logcat (`GoogleProvider`) for `signingSha1=` and `package=`.
+3. In [Google Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials), open your **Android** OAuth client and verify that **exact** package name and SHA-1 are listed.
+4. If testing a **release** build, register the SHA-1 from that build — not only the debug keystore.
+5. If the app is distributed via **Play Store**, also register the **Play App Signing** SHA-1.
+6. Ensure Web and Android clients live in the **same** Google Cloud project.
+7. If consent screen is in Testing, confirm the Google account is a **test user**.
+8. Wait and retry after console changes.
+
+`USER_CANCELLED` after picking an account on a misconfigured debug build can still be a SHA-1 / client-ID mismatch — fix the console setup above first.
+
+##### Extract SHA-1 from the build you install
+
+Debug / local builds:
+
+```bash
+cd android && ./gradlew signingReport
+```
+
+Signed release APK:
+
+```bash
+keytool -printcert -jarfile android/app/release/app-release.apk
+```
+
+Then add that SHA-1 to an Android OAuth client (package name + SHA-1) in Google Cloud Console, reinstall the **same** signed APK, and test again:
+
+```bash
+adb install android/app/release/app-release.apk
+```
+
+##### Reading the login result (Firebase and backends)
+
+Tokens are nested under `result`:
+
+```ts
+const login = await SocialLogin.login({ provider: 'google' });
+const idToken = login.result?.idToken; // not login.idToken
+```
+
+For Firebase Auth, create credentials with that `idToken` and use the **Web** Client ID as `webClientId` in `initialize`.
 
 ### iOS configuration
 
@@ -689,6 +743,12 @@ const config: CapacitorConfig = {
 ```
 
 Then run `npx cap sync`. The plugin uses stub classes instead of the real Facebook SDK, so no Facebook dependencies or permissions are included in your build.
+
+### Google Sign-In `[28444] Developer console is not set up correctly` (Android)
+
+On Android, this error comes from **Google Credential Manager** when the installed APK's signing certificate, package name, or `webClientId` does not match Google Cloud Console.
+
+See [Android troubleshooting (Credential Manager, SHA-1, and Firebase)](#android-troubleshooting-credential-manager-sha-1-and-firebase) for the full checklist. After a failed login, filter Logcat for `GoogleProvider` — the plugin prints `package`, `signingSha1`, and `webClientId` to compare with your OAuth clients.
 
 ### Google Sign-In with Family Link Supervised Accounts
 
@@ -1362,7 +1422,9 @@ Configuration for a single OAuth2 provider instance
 
 Construct a type with a set of properties K of type T
 
-<code>{ [P in K]: T; }</code>
+<code>{
+ [P in K]: T;
+ }</code>
 
 
 #### ProviderResponseMap

--- a/android/src/main/java/ee/forgr/capacitor/social/login/GoogleProvider.java
+++ b/android/src/main/java/ee/forgr/capacitor/social/login/GoogleProvider.java
@@ -9,8 +9,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.Signature;
 import android.os.Build;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.concurrent.futures.CallbackToFutureAdapter;
@@ -38,6 +36,8 @@ import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential;
 import com.google.common.util.concurrent.ListenableFuture;
 import ee.forgr.capacitor.social.login.helpers.SocialProvider;
 import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -88,7 +88,6 @@ public class GoogleProvider implements SocialProvider {
     private String accessToken = null;
     private GoogleProviderLoginType mode = GoogleProviderLoginType.ONLINE;
     private String hostedDomain = null;
-
 
     private static String maskClientId(String clientId) {
         if (clientId == null || clientId.isEmpty()) {

--- a/android/src/main/java/ee/forgr/capacitor/social/login/GoogleProvider.java
+++ b/android/src/main/java/ee/forgr/capacitor/social/login/GoogleProvider.java
@@ -5,6 +5,12 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.Signature;
+import android.os.Build;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.concurrent.futures.CallbackToFutureAdapter;
@@ -83,6 +89,76 @@ public class GoogleProvider implements SocialProvider {
     private GoogleProviderLoginType mode = GoogleProviderLoginType.ONLINE;
     private String hostedDomain = null;
 
+
+    private static String maskClientId(String clientId) {
+        if (clientId == null || clientId.isEmpty()) {
+            return "(not set)";
+        }
+        if (clientId.length() <= 16) {
+            return clientId;
+        }
+        return "..." + clientId.substring(clientId.length() - 20);
+    }
+
+    private static String getSigningCertificateSha1(Context context) {
+        try {
+            PackageManager pm = context.getPackageManager();
+            String packageName = context.getPackageName();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                PackageInfo info = pm.getPackageInfo(packageName, PackageManager.GET_SIGNING_CERTIFICATES);
+                if (info.signingInfo != null) {
+                    Signature[] signatures = info.signingInfo.getApkContentsSigners();
+                    if (signatures != null && signatures.length > 0) {
+                        return sha1Fingerprint(signatures[0]);
+                    }
+                }
+            } else {
+                @SuppressWarnings("deprecation")
+                PackageInfo info = pm.getPackageInfo(packageName, PackageManager.GET_SIGNATURES);
+                @SuppressWarnings("deprecation")
+                Signature[] signatures = info.signatures;
+                if (signatures != null && signatures.length > 0) {
+                    return sha1Fingerprint(signatures[0]);
+                }
+            }
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.w(LOG_TAG, "Could not read app signing certificate", e);
+        }
+        return null;
+    }
+
+    private static String sha1Fingerprint(Signature signature) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            byte[] digest = md.digest(signature.toByteArray());
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < digest.length; i++) {
+                if (i > 0) {
+                    sb.append(':');
+                }
+                sb.append(String.format("%02X", digest[i]));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+    }
+
+    private void logGoogleCloudDiagnostics(String phase) {
+        String sha1 = getSigningCertificateSha1(context);
+        Log.i(
+            LOG_TAG,
+            String.format(
+                "Google %s: package=%s signingSha1=%s webClientId=%s mode=%s",
+                phase,
+                context.getPackageName(),
+                sha1 != null ? sha1 : "unknown",
+                maskClientId(clientId),
+                mode != null ? mode.name() : "unknown"
+            )
+        );
+    }
+
     public enum GoogleProviderLoginType {
         ONLINE,
         OFFLINE
@@ -102,6 +178,7 @@ public class GoogleProvider implements SocialProvider {
         this.clientId = clientId;
         this.mode = mode;
         this.hostedDomain = hostedDomain;
+        logGoogleCloudDiagnostics("initialize");
 
         String data = context.getSharedPreferences(SHARED_PREFERENCE_NAME, Context.MODE_PRIVATE).getString(GOOGLE_DATA_PREFERENCE, null);
 
@@ -301,6 +378,8 @@ public class GoogleProvider implements SocialProvider {
             return;
         }
 
+        logGoogleCloudDiagnostics("login");
+
         String nonce = config.optString("nonce");
         JSONObject options = call.getObject("options", new JSObject());
         boolean bottomUi = false;
@@ -346,8 +425,19 @@ public class GoogleProvider implements SocialProvider {
         // Build credential request
         GetCredentialRequest.Builder requestBuilder = new GetCredentialRequest.Builder();
 
+        Log.i(
+            LOG_TAG,
+            String.format(
+                "Google login request: ui=%s filterByAuthorizedAccounts=%s autoSelectEnabled=%s forcePrompt=%s nonceSet=%s",
+                bottomUi ? "bottom" : "standard",
+                filterByAuthorizedAccounts,
+                autoSelectEnabled,
+                forcePrompt,
+                !nonce.isEmpty()
+            )
+        );
+
         if (bottomUi) {
-            Log.e(LOG_TAG, "use bottomUi");
             GetGoogleIdOption.Builder googleIdOptionBuilder = new GetGoogleIdOption.Builder().setServerClientId(this.clientId);
             // Handle bottom UI specific options
             if (forcePrompt) {
@@ -642,8 +732,43 @@ public class GoogleProvider implements SocialProvider {
         }
     }
 
+    private boolean isDeveloperConsoleMisconfiguration(String message) {
+        return message.contains("Developer console") || message.contains("28444") || message.contains("10:");
+    }
+
+    private void logDeveloperConsoleMisconfigurationHelp(String errorMessage) {
+        String sha1 = getSigningCertificateSha1(context);
+        Log.e(
+            LOG_TAG,
+            String.format(
+                "Google Credential Manager rejected this app (%s). package=%s signingSha1=%s webClientId=%s. " +
+                    "Checklist: (1) webClientId must be a Web OAuth client ID, not Android; " +
+                    "(2) create an Android OAuth client with this exact package + SHA-1 in the same GCP project; " +
+                    "(3) add Play App Signing SHA-1 for Play Store builds; " +
+                    "(4) add test users if OAuth consent screen is in Testing; " +
+                    "(5) allow several hours for console changes to propagate.",
+                errorMessage,
+                context.getPackageName(),
+                sha1 != null ? sha1 : "unknown",
+                maskClientId(clientId)
+            )
+        );
+    }
+
     private void handleSignInError(GetCredentialException e, PluginCall call, JSONObject config) {
-        Log.e(LOG_TAG, "Google Sign-In failed", e);
+        String errorMessage = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+        Log.e(LOG_TAG, "Google Sign-In failed: " + errorMessage, e);
+
+        if (isDeveloperConsoleMisconfiguration(errorMessage)) {
+            logDeveloperConsoleMisconfigurationHelp(errorMessage);
+            call.reject(
+                "Google Sign-In failed: Google Cloud OAuth is not configured for this installed build (" +
+                    errorMessage +
+                    "). Check Logcat tag GoogleProvider for package, signingSha1, and webClientId, then see the Android troubleshooting section in the plugin README."
+            );
+            return;
+        }
+
         boolean isBottomUi = false;
         JSONObject options = call.getObject("options", new JSObject());
         if (options.has("style")) {

--- a/docs/setup_google.md
+++ b/docs/setup_google.md
@@ -1,3 +1,24 @@
 # Google Sign-In Setup
 
-Documentation for this plugin moved to: https://capgo.app/docs/plugins/social-login/
+Full setup guide: https://capgo.app/docs/plugins/social-login/
+
+## Android quick reference (Credential Manager)
+
+This plugin uses **Google Credential Manager** on Android. You need OAuth clients in the **same** Google Cloud project:
+
+1. **Web application** client → pass its ID as `webClientId` in `SocialLogin.initialize()`.
+2. **Android** client(s) → register package name + SHA-1 for each signing key (debug, release, Play App Signing). Never use the Android client ID as `webClientId`.
+
+### Logcat diagnostics
+
+After `SocialLogin.initialize()` and on failed login, filter Logcat for `GoogleProvider` or `CapgoSocialLogin`. The plugin logs:
+
+- `package` — must match your Android OAuth client
+- `signingSha1` — must be registered on that Android OAuth client
+- masked `webClientId` — must be the **Web** client ID
+
+### `[28444] Developer console is not set up correctly`
+
+See the **Android troubleshooting** section in [README.md](../README.md#android-troubleshooting-credential-manager-sha-1-and-firebase) for the full checklist. In short: wrong `webClientId` type, missing SHA-1 for the installed APK, package name mismatch, missing Play App Signing SHA-1, or OAuth consent screen test users.
+
+Config changes in Google Cloud can take several hours to take effect.


### PR DESCRIPTION
## Summary

- Expands Android Google Sign-In troubleshooting for Credential Manager errors, especially `[28444] Developer console is not set up correctly` ([#422](https://github.com/Cap-go/capacitor-social-login/issues/422))
- Documents the Web vs Android OAuth client split, SHA-1 sources (debug, release APK, Play App Signing), consent-screen test users, and answers that Digital Asset Links are not required
- Adds Android diagnostic logging: on `initialize`/`login` and on configuration failures, Logcat (`GoogleProvider`) prints `package`, `signingSha1`, and masked `webClientId` plus an actionable checklist

## Test plan

- [x] `bun run verify:android`
- [ ] Review README and `docs/setup_google.md` wording
- [ ] Confirm Logcat output on a device with a misconfigured Google Cloud project shows package + SHA-1

Closes #422


Made with [Cursor](https://cursor.com)