### PR TITLE
[codex] allow Apple broadcast init without redirect URL

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/social/login/AppleProvider.java
+++ b/android/src/main/java/ee/forgr/capacitor/social/login/AppleProvider.java
@@ -151,18 +151,18 @@ public class AppleProvider implements SocialProvider {
             return;
         }
 
-        // Save the call reference immediately so it's always available
+        boolean useBroadcastChannel = config.optBoolean("useBroadcastChannel", this.useBroadcastChannel);
+        if (SocialLoginPlugin.shouldRejectMissingAppleRedirectUrl(this.redirectUrl, useBroadcastChannel)) {
+            call.reject("apple.android.redirectUrl is null or empty");
+            return;
+        }
+
         this.lastcall = call;
         call.setKeepAlive(true);
 
-        // Check if Broadcast Channel is enabled
-        boolean useBroadcastChannel = config.optBoolean("useBroadcastChannel", this.useBroadcastChannel);
-
         if (useBroadcastChannel) {
-            // Use Broadcast Channel approach - simplified flow
             loginWithBroadcastChannel(call, config);
         } else {
-            // Use traditional URL redirect approach
             loginWithRedirect(call, config);
         }
     }

--- a/android/src/main/java/ee/forgr/capacitor/social/login/SocialLoginPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/social/login/SocialLoginPlugin.java
@@ -48,12 +48,6 @@ public class SocialLoginPlugin extends Plugin {
                 return;
             }
 
-            String androidAppleRedirect = apple.getString("redirectUrl");
-            if (androidAppleRedirect == null || androidAppleRedirect.isEmpty()) {
-                call.reject("apple.android.redirectUrl is null or empty");
-                return;
-            }
-
             String androidAppleClientId = apple.getString("clientId");
             if (androidAppleClientId == null || androidAppleClientId.isEmpty()) {
                 call.reject("apple.android.clientId is null or empty");
@@ -62,6 +56,11 @@ public class SocialLoginPlugin extends Plugin {
 
             boolean useProperTokenExchange = apple.has("useProperTokenExchange") ? apple.getBool("useProperTokenExchange") : false;
             boolean useBroadcastChannel = apple.has("useBroadcastChannel") ? apple.getBool("useBroadcastChannel") : false;
+            String androidAppleRedirect = apple.getString("redirectUrl");
+            if (shouldRejectMissingAppleRedirectUrl(androidAppleRedirect, useBroadcastChannel)) {
+                call.reject("apple.android.redirectUrl is null or empty");
+                return;
+            }
 
             AppleProvider appleProvider = new AppleProvider(
                 androidAppleRedirect,
@@ -190,6 +189,10 @@ public class SocialLoginPlugin extends Plugin {
         }
 
         call.resolve();
+    }
+
+    static boolean shouldRejectMissingAppleRedirectUrl(String redirectUrl, boolean useBroadcastChannel) {
+        return !useBroadcastChannel && (redirectUrl == null || redirectUrl.isEmpty());
     }
 
     @PluginMethod

--- a/android/src/test/java/ee/forgr/capacitor/social/login/SocialLoginPluginTest.java
+++ b/android/src/test/java/ee/forgr/capacitor/social/login/SocialLoginPluginTest.java
@@ -1,0 +1,22 @@
+package ee.forgr.capacitor.social.login;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class SocialLoginPluginTest {
+
+    @Test
+    public void shouldAllowMissingAppleRedirectUrlForBroadcastChannel() {
+        assertFalse(SocialLoginPlugin.shouldRejectMissingAppleRedirectUrl(null, true));
+        assertFalse(SocialLoginPlugin.shouldRejectMissingAppleRedirectUrl("", true));
+    }
+
+    @Test
+    public void shouldRequireAppleRedirectUrlForRedirectFlow() {
+        assertTrue(SocialLoginPlugin.shouldRejectMissingAppleRedirectUrl(null, false));
+        assertTrue(SocialLoginPlugin.shouldRejectMissingAppleRedirectUrl("", false));
+        assertFalse(SocialLoginPlugin.shouldRejectMissingAppleRedirectUrl("app://callback", false));
+    }
+}


### PR DESCRIPTION
## What changed
- Reads `useBroadcastChannel` before enforcing the Android Apple `redirectUrl` requirement during initialization.
- Keeps missing or empty `redirectUrl` rejected for the normal redirect flow.
- Applies the same guard when login options override the initialized Apple broadcast mode.
- Adds focused Android unit coverage for the redirect guard.

## Root cause
Android initialization rejected an empty Apple `redirectUrl` before reading `useBroadcastChannel`, so documented Broadcast Channel configuration without a redirect URL failed to register the Apple provider.

## User impact
Android apps using Apple Broadcast Channel mode can initialize without `redirectUrl`. Existing redirect-based Android Apple auth still requires `redirectUrl` and keeps the previous rejection behavior.

## Validation
- `bun install --frozen-lockfile`
- `bun run check:wiring`
- `bun run verify:android`
- `bunx prettier --check android/src/main/java/ee/forgr/capacitor/social/login/SocialLoginPlugin.java android/src/main/java/ee/forgr/capacitor/social/login/AppleProvider.java android/src/test/java/ee/forgr/capacitor/social/login/SocialLoginPluginTest.java --plugin=prettier-plugin-java`
- `bun run verify:web`
- `bun run verify:ios`

Fixes #70
