### PR TITLE
[codex] document Keycloak OAuth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Use the Auth Connect preset wrapper (`SocialLoginAuthConnect`) to log in with `a
 
 - Compatibility guide: https://github.com/Cap-go/capacitor-social-login/blob/main/docs/auth_connect_compatibility.md
 - Migration guide: https://github.com/Cap-go/capacitor-social-login/blob/main/MIGRATION_AUTH_CONNECT.md
+- Keycloak setup: https://github.com/Cap-go/capacitor-social-login/blob/main/docs/setup_keycloak.md
 
 ## Documentation
 
@@ -538,7 +539,9 @@ On Web, Google `refresh()` is not implemented, even when using `mode: 'online'`.
 
 ## OAuth2 (Generic)
 
-The plugin supports generic OAuth2 authentication, allowing you to integrate with any OAuth2-compliant provider (GitHub, Azure AD, Auth0, Okta, custom servers, etc.). You can configure multiple OAuth2 providers simultaneously.
+The plugin supports generic OAuth2 authentication, allowing you to integrate with any OAuth2-compliant provider (GitHub, Azure AD, Auth0, Okta, Keycloak, custom servers, etc.). You can configure multiple OAuth2 providers simultaneously.
+
+For Keycloak, use the generic OAuth2 provider with your realm issuer URL. See the [Keycloak setup guide](./docs/setup_keycloak.md).
 
 ### Multi-Provider Configuration
 
@@ -677,8 +680,9 @@ await SocialLogin.refresh({
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `appId` | string | Yes | OAuth2 Client ID |
-| `authorizationBaseUrl` | string | Yes | Authorization endpoint URL |
-| `accessTokenEndpoint` | string | No* | Token endpoint URL (*Required for code flow) |
+| `issuerUrl` | string | No* | OpenID Connect issuer URL for discovery (*Use this or `authorizationBaseUrl`) |
+| `authorizationBaseUrl` | string | No* | Authorization endpoint URL (*Use this or `issuerUrl`) |
+| `accessTokenEndpoint` | string | No* | Token endpoint URL (*Required for code flow without `issuerUrl`) |
 | `redirectUrl` | string | Yes | Callback URL for OAuth redirect |
 | `responseType` | 'code' \| 'token' | No | OAuth flow type (default: 'code') |
 | `pkceEnabled` | boolean | No | Enable PKCE (default: true) |

--- a/README.md
+++ b/README.md
@@ -680,9 +680,9 @@ await SocialLogin.refresh({
 | Option | Type | Required | Description |
 |--------|------|----------|-------------|
 | `appId` | string | Yes | OAuth2 Client ID |
-| `issuerUrl` | string | No* | OpenID Connect issuer URL for discovery (*Use this or `authorizationBaseUrl`) |
-| `authorizationBaseUrl` | string | No* | Authorization endpoint URL (*Use this or `issuerUrl`) |
-| `accessTokenEndpoint` | string | No* | Token endpoint URL (*Required for code flow without `issuerUrl`) |
+| `issuerUrl` | string | No* | OpenID Connect issuer URL for discovery (*Use this or an authorization endpoint) |
+| `authorizationBaseUrl` / `authorizationEndpoint` | string | No* | Authorization endpoint URL aliases for the same setting (*Use one alias or `issuerUrl`) |
+| `accessTokenEndpoint` / `tokenEndpoint` | string | No* | Token endpoint URL aliases for the same setting (*Required for code flow without `issuerUrl`) |
 | `redirectUrl` | string | Yes | Callback URL for OAuth redirect |
 | `responseType` | 'code' \| 'token' | No | OAuth flow type (default: 'code') |
 | `pkceEnabled` | boolean | No | Enable PKCE (default: true) |

--- a/docs/auth_connect_compatibility.md
+++ b/docs/auth_connect_compatibility.md
@@ -46,6 +46,37 @@ await SocialLoginAuthConnect.logout({ provider: 'auth0' });
 
 These provider IDs are mapped to the existing OAuth2 provider internally.
 
+## Keycloak
+
+Keycloak is not one of the Auth Connect preset provider IDs. Use the generic `oauth2` provider with a stable `providerId`, such as `keycloak`.
+
+```typescript
+import { SocialLoginAuthConnect } from '@capgo/capacitor-social-login';
+
+const keycloakIssuer = 'https://keycloak.example.com/realms/my-realm';
+
+await SocialLoginAuthConnect.initialize({
+  oauth2: {
+    keycloak: {
+      appId: 'your-keycloak-client-id',
+      issuerUrl: keycloakIssuer,
+      redirectUrl: 'myapp://oauth/keycloak',
+      scope: 'openid profile email',
+      pkceEnabled: true,
+    },
+  },
+});
+
+const result = await SocialLoginAuthConnect.login({
+  provider: 'oauth2',
+  options: {
+    providerId: 'keycloak',
+  },
+});
+```
+
+See the full Keycloak guide in `docs/setup_keycloak.md`.
+
 ## Overriding endpoints and defaults
 
 Each preset builds a default OAuth2 configuration based on `domain` or `issuer`. If your tenant uses custom endpoints,

--- a/docs/setup_keycloak.md
+++ b/docs/setup_keycloak.md
@@ -1,0 +1,93 @@
+# Keycloak OAuth/OIDC setup
+
+Keycloak works through the built-in generic OAuth2 provider. You do not need a new native provider for Keycloak; configure your Keycloak client as an OpenID Connect client and use `provider: 'oauth2'` with a `providerId` such as `keycloak`.
+
+## Keycloak client settings
+
+In your Keycloak realm, create or open the client used by your Capacitor app:
+
+1. Use the authorization code flow.
+2. Keep PKCE enabled in the app config.
+3. Register every redirect URI that your app uses, for example `myapp://oauth/keycloak` for mobile and an HTTPS callback URL for production web.
+4. Use scopes such as `openid profile email`. Add `offline_access` only when your realm/client is configured to issue refresh tokens.
+
+The exact issuer URL is deployment-specific. Current Keycloak deployments commonly publish realm metadata at `https://keycloak.example.com/realms/my-realm/.well-known/openid-configuration`, but some deployments include an extra base path. Use the issuer URL shown by your realm's OpenID Endpoint Configuration instead of guessing.
+
+## Configure the plugin
+
+Prefer `issuerUrl` so the plugin can discover the authorization, token, and logout endpoints from the realm metadata:
+
+```typescript
+import { SocialLogin } from '@capgo/capacitor-social-login';
+
+const keycloakIssuer = 'https://keycloak.example.com/realms/my-realm';
+
+await SocialLogin.initialize({
+  oauth2: {
+    keycloak: {
+      appId: 'your-keycloak-client-id',
+      issuerUrl: keycloakIssuer,
+      redirectUrl: 'myapp://oauth/keycloak',
+      scope: 'openid profile email',
+      pkceEnabled: true,
+      resourceUrl: `${keycloakIssuer}/protocol/openid-connect/userinfo`,
+    },
+  },
+});
+
+const result = await SocialLogin.login({
+  provider: 'oauth2',
+  options: {
+    providerId: 'keycloak',
+  },
+});
+
+console.log(result.result.idToken);
+console.log(result.result.accessToken?.token);
+console.log(result.result.resourceData);
+```
+
+For refresh tokens, request `offline_access` only if your Keycloak realm and client allow refresh tokens for this app:
+
+```typescript
+await SocialLogin.initialize({
+  oauth2: {
+    keycloak: {
+      appId: 'your-keycloak-client-id',
+      issuerUrl: keycloakIssuer,
+      redirectUrl: 'myapp://oauth/keycloak',
+      scope: 'openid profile email offline_access',
+      pkceEnabled: true,
+    },
+  },
+});
+```
+
+## Manual endpoint fallback
+
+If OIDC discovery is blocked or your deployment does not expose metadata to the app, configure the endpoints directly. Keep the base URL exactly as your Keycloak deployment publishes it:
+
+```typescript
+const keycloakRealmUrl = 'https://keycloak.example.com/realms/my-realm';
+
+await SocialLogin.initialize({
+  oauth2: {
+    keycloak: {
+      appId: 'your-keycloak-client-id',
+      authorizationBaseUrl: `${keycloakRealmUrl}/protocol/openid-connect/auth`,
+      accessTokenEndpoint: `${keycloakRealmUrl}/protocol/openid-connect/token`,
+      redirectUrl: 'myapp://oauth/keycloak',
+      scope: 'openid profile email',
+      pkceEnabled: true,
+      resourceUrl: `${keycloakRealmUrl}/protocol/openid-connect/userinfo`,
+      logoutUrl: `${keycloakRealmUrl}/protocol/openid-connect/logout`,
+    },
+  },
+});
+```
+
+## Auth Connect compatibility
+
+Keycloak is not one of the Auth Connect preset provider IDs. If you already use `SocialLoginAuthConnect`, you can still initialize the generic `oauth2` provider and log in with `provider: 'oauth2'` plus `providerId: 'keycloak'`.
+
+See the Keycloak OpenID Connect endpoint reference for the discovery and endpoint paths: https://www.keycloak.org/securing-apps/oidc-layers


### PR DESCRIPTION
## What changed

- Added `docs/setup_keycloak.md` with Keycloak OAuth/OIDC setup through the existing generic `oauth2` provider.
- Linked the Keycloak guide from the README and Auth Connect compatibility docs.
- Clarified that `issuerUrl` can be used for OIDC discovery instead of hardcoding OAuth endpoints.

## Why

Issue #409 asks for Keycloak support. The plugin already supports OAuth/OIDC via the generic OAuth2 flow, so the low-risk fix is documenting the supported setup instead of adding a new native provider.

## Impact

Docs-only change. No runtime code, native code, dependencies, or generated package output changed.

## Validation

- `bun install --frozen-lockfile`
- `git diff --check`
- `bunx prettier --check docs/auth_connect_compatibility.md docs/setup_keycloak.md`
- `bun run build`
- `bun run lint` fails in existing untouched SwiftLint violations under `ios/Sources/SocialLoginPlugin/*.swift`; ESLint and the configured prettier script completed before SwiftLint failed.

Fixes #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a dedicated Keycloak section to the authentication compatibility guide, explaining it’s configured via the generic OAuth2 provider with a stable `keycloak` provider ID.
  * Introduced `setup_keycloak` documentation covering Keycloak client requirements, PKCE, scopes, redirect URIs, and example initialization/login usage.
  * Updated the OAuth2 configuration reference to support `issuerUrl` (OIDC discovery) and clarified when `authorizationBaseUrl` and `accessTokenEndpoint` are optional versus required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->