### PR TITLE
fix(ios): honor provider config in Swift Package Manager builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export default config;
 - This configuration only affects iOS and Android platforms; it does not affect the web platform.
 - **Important**: Using `false` means the dependency won't be bundled, but the plugin code still compiles against it. Ensure the consuming app includes the dependency if needed.
 - **Facebook**: When `facebook: false`, the Facebook SDK is omitted and the plugin compiles a provider stub in its own package — no `com.facebook.*` classes are shipped (avoids privacy-scanner false positives).
-- **Apple (iOS)**: Basic Sign in with Apple always works via AuthenticationServices (no external SDK). Alamofire is only required when using `redirectUrl` / backend token exchange. CocoaPods and Swift Package Manager both toggle Alamofire via `apple: true|false`.
+- **Apple (iOS)**: `apple: true` enables Sign in with Apple (AuthenticationServices; no external SDK for basic login). Alamofire is only linked when using `redirectUrl` / backend token exchange. `apple: false` removes Alamofire and disables Apple authentication at runtime—including basic Sign in with Apple—consistent with the rule above that `false` providers are unavailable at runtime. CocoaPods and Swift Package Manager both toggle Alamofire based on `apple: true|false`.
 - Apple Sign-In on Android uses OAuth flow without external SDK dependencies
 - Twitter uses standard OAuth 2.0 flow without external SDK dependencies
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export default config;
 - This configuration only affects iOS and Android platforms; it does not affect the web platform.
 - **Important**: Using `false` means the dependency won't be bundled, but the plugin code still compiles against it. Ensure the consuming app includes the dependency if needed.
 - **Facebook**: When `facebook: false`, the Facebook SDK is omitted and the plugin compiles a provider stub in its own package — no `com.facebook.*` classes are shipped (avoids privacy-scanner false positives).
-- **Apple (iOS)**: Basic Sign in with Apple always works via AuthenticationServices (no external SDK). Alamofire is only required when using `redirectUrl` / backend token exchange. CocoaPods toggles Alamofire via `apple: true|false`; SPM always resolves Alamofire from `Package.swift` when the plugin is linked.
+- **Apple (iOS)**: Basic Sign in with Apple always works via AuthenticationServices (no external SDK). Alamofire is only required when using `redirectUrl` / backend token exchange. CocoaPods and Swift Package Manager both toggle Alamofire via `apple: true|false`.
 - Apple Sign-In on Android uses OAuth flow without external SDK dependencies
 - Twitter uses standard OAuth 2.0 flow without external SDK dependencies
 

--- a/scripts/configure-dependencies.ts
+++ b/scripts/configure-dependencies.ts
@@ -277,10 +277,12 @@ function applyDependencyReplacements(
 }
 
 function getPodspecReplacements(providerConfig: ProviderConfig): DependencyReplacement[] {
+  const podspecTrailingComment = '([ \\t]*#[^\\r\\n]*)?';
+
   return [
     {
       // Google SignIn - handle both active and commented (including existing disabled comments)
-      old: /(#\s*)?s\.dependency\s+'GoogleSignIn',\s*'~>\s*9\.0\.0'(\s*#.*)?/,
+      old: new RegExp(`(#[ \\t]*)?s\\.dependency\\s+'GoogleSignIn',\\s*'~>\\s*9\\.0\\.0'${podspecTrailingComment}`),
       new:
         providerConfig.google === 'implementation'
           ? `s.dependency 'GoogleSignIn', '~> 9.0.0'`
@@ -288,7 +290,7 @@ function getPodspecReplacements(providerConfig: ProviderConfig): DependencyRepla
     },
     {
       // Facebook Core - handle both active and commented (including existing disabled comments)
-      old: /(#\s*)?s\.dependency\s+'FBSDKCoreKit',\s*'~>\s*18\.0'(\s*#.*)?/,
+      old: new RegExp(`(#[ \\t]*)?s\\.dependency\\s+'FBSDKCoreKit',\\s*'~>\\s*18\\.0'${podspecTrailingComment}`),
       new:
         providerConfig.facebook === 'implementation'
           ? `s.dependency 'FBSDKCoreKit', '~> 18.0'`
@@ -296,7 +298,7 @@ function getPodspecReplacements(providerConfig: ProviderConfig): DependencyRepla
     },
     {
       // Facebook Login - handle both active and commented (including existing disabled comments)
-      old: /(#\s*)?s\.dependency\s+'FBSDKLoginKit',\s*'~>\s*18\.0'(\s*#.*)?/,
+      old: new RegExp(`(#[ \\t]*)?s\\.dependency\\s+'FBSDKLoginKit',\\s*'~>\\s*18\\.0'${podspecTrailingComment}`),
       new:
         providerConfig.facebook === 'implementation'
           ? `s.dependency 'FBSDKLoginKit', '~> 18.0'`
@@ -304,7 +306,7 @@ function getPodspecReplacements(providerConfig: ProviderConfig): DependencyRepla
     },
     {
       // Alamofire (for Apple) - handle both active and commented (including existing disabled comments)
-      old: /(#\s*)?s\.dependency\s+'Alamofire',\s*'~>\s*5\.10\.2'(\s*#.*)?/,
+      old: new RegExp(`(#[ \\t]*)?s\\.dependency\\s+'Alamofire',\\s*'~>\\s*5\\.10\\.2'${podspecTrailingComment}`),
       new:
         providerConfig.apple === 'implementation'
           ? `s.dependency 'Alamofire', '~> 5.10.2'`
@@ -314,8 +316,8 @@ function getPodspecReplacements(providerConfig: ProviderConfig): DependencyRepla
 }
 
 function getPackageSwiftReplacements(providerConfig: ProviderConfig): DependencyReplacement[] {
-  const swiftCommentPrefix = '(?:\\/\\/\\s*)*';
-  const swiftTrailingComment = '(?:\\s*\\/\\/.*)?';
+  const swiftCommentPrefix = '(?:\\/\\/[ \\t]*)*';
+  const swiftTrailingComment = '(?:[ \\t]*\\/\\/[^\\r\\n]*)?';
 
   return [
     {
@@ -387,8 +389,9 @@ function getPackageSwiftReplacements(providerConfig: ProviderConfig): Dependency
 /**
  * Modify Podspec and Package.swift for iOS conditional dependencies
  */
-function configureIOS(providerConfig: ProviderConfig): void {
+function configureIOS(providerConfig: ProviderConfig): boolean {
   logInfo('Configuring iOS dependencies...');
+  let success = true;
 
   try {
     const podspecResult = applyDependencyReplacements(
@@ -404,14 +407,15 @@ function configureIOS(providerConfig: ProviderConfig): void {
     }
   } catch (error) {
     logError(`Error modifying podspec: ${(error as Error).message}`);
+    success = false;
+  }
+
+  if (!fs.existsSync(packageSwiftPath)) {
+    logError('Package.swift not found; Swift Package Manager configuration is required');
+    return false;
   }
 
   try {
-    if (!fs.existsSync(packageSwiftPath)) {
-      logWarning('Package.swift not found, skipping Swift Package Manager configuration');
-      return;
-    }
-
     const packageSwiftResult = applyDependencyReplacements(
       fs.readFileSync(packageSwiftPath, 'utf8'),
       getPackageSwiftReplacements(providerConfig),
@@ -425,7 +429,10 @@ function configureIOS(providerConfig: ProviderConfig): void {
     }
   } catch (error) {
     logError(`Error modifying Package.swift: ${(error as Error).message}`);
+    success = false;
   }
+
+  return success;
 }
 
 // ============================================================================
@@ -448,6 +455,8 @@ function configureWeb(): void {
  * Main execution
  */
 function main(): void {
+  let configurationSucceeded = true;
+
   // Route to platform-specific configuration
   switch (PLATFORM) {
     case 'android':
@@ -456,7 +465,6 @@ function main(): void {
       logInfo('Configuring dynamic provider dependencies for SocialLogin');
       logProviderConfig(androidConfig);
       configureAndroid(androidConfig);
-      logSuccess('Configuration complete\n');
       break;
 
     case 'ios':
@@ -464,8 +472,7 @@ function main(): void {
       const iosConfig = getProviderConfig();
       logInfo('Configuring dynamic provider dependencies for SocialLogin');
       logProviderConfig(iosConfig);
-      configureIOS(iosConfig);
-      logSuccess('Configuration complete\n');
+      configurationSucceeded = configureIOS(iosConfig);
       break;
 
     case 'web':
@@ -481,10 +488,16 @@ function main(): void {
       logProviderConfig(defaultConfig);
       logWarning(`Unknown platform: ${PLATFORM || 'undefined'}, configuring all platforms`);
       configureAndroid(defaultConfig);
-      configureIOS(defaultConfig);
-      logSuccess('Configuration complete\n');
+      configurationSucceeded = configureIOS(defaultConfig);
       break;
   }
+
+  if (!configurationSucceeded) {
+    logError('Configuration failed\n');
+    process.exit(1);
+  }
+
+  logSuccess('Configuration complete\n');
 }
 
 // Run if executed directly

--- a/scripts/configure-dependencies.ts
+++ b/scripts/configure-dependencies.ts
@@ -28,6 +28,7 @@ const PLATFORM = process.env.CAPACITOR_PLATFORM_NAME;
 // const androidGradlePath = path.join(PLUGIN_ROOT, 'android', 'build.gradle');
 const gradlePropertiesPath = path.join(PLUGIN_ROOT, 'android', 'gradle.properties');
 const podspecPath = path.join(PLUGIN_ROOT, 'CapgoCapacitorSocialLogin.podspec');
+const packageSwiftPath = path.join(PLUGIN_ROOT, 'Package.swift');
 
 // Default provider configuration (backward compatible)
 const defaultProviders: Record<string, string | boolean> = {
@@ -247,74 +248,183 @@ function configureAndroid(providerConfig: ProviderConfig): void {
 }
 
 // ============================================================================
-// iOS: Podspec Configuration
+// iOS: Podspec and Swift Package Manager Configuration
 // ============================================================================
 
+type DependencyReplacement = { old: RegExp; new: string };
+
+function applyDependencyReplacements(
+  content: string,
+  replacements: DependencyReplacement[],
+): {
+  content: string;
+  modified: boolean;
+} {
+  let updatedContent = content;
+  let modified = false;
+
+  for (const replacement of replacements) {
+    if (replacement.old.test(updatedContent)) {
+      const before = updatedContent;
+      updatedContent = updatedContent.replace(replacement.old, replacement.new);
+      if (before !== updatedContent) {
+        modified = true;
+      }
+    }
+  }
+
+  return { content: updatedContent, modified };
+}
+
+function getPodspecReplacements(providerConfig: ProviderConfig): DependencyReplacement[] {
+  return [
+    {
+      // Google SignIn - handle both active and commented (including existing disabled comments)
+      old: /(#\s*)?s\.dependency\s+'GoogleSignIn',\s*'~>\s*9\.0\.0'(\s*#.*)?/,
+      new:
+        providerConfig.google === 'implementation'
+          ? `s.dependency 'GoogleSignIn', '~> 9.0.0'`
+          : `# s.dependency 'GoogleSignIn', '~> 9.0.0'  # Disabled via config (compileOnly)`,
+    },
+    {
+      // Facebook Core - handle both active and commented (including existing disabled comments)
+      old: /(#\s*)?s\.dependency\s+'FBSDKCoreKit',\s*'~>\s*18\.0'(\s*#.*)?/,
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `s.dependency 'FBSDKCoreKit', '~> 18.0'`
+          : `# s.dependency 'FBSDKCoreKit', '~> 18.0'  # Disabled via config (compileOnly)`,
+    },
+    {
+      // Facebook Login - handle both active and commented (including existing disabled comments)
+      old: /(#\s*)?s\.dependency\s+'FBSDKLoginKit',\s*'~>\s*18\.0'(\s*#.*)?/,
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `s.dependency 'FBSDKLoginKit', '~> 18.0'`
+          : `# s.dependency 'FBSDKLoginKit', '~> 18.0'  # Disabled via config (compileOnly)`,
+    },
+    {
+      // Alamofire (for Apple) - handle both active and commented (including existing disabled comments)
+      old: /(#\s*)?s\.dependency\s+'Alamofire',\s*'~>\s*5\.10\.2'(\s*#.*)?/,
+      new:
+        providerConfig.apple === 'implementation'
+          ? `s.dependency 'Alamofire', '~> 5.10.2'`
+          : `# s.dependency 'Alamofire', '~> 5.10.2'  # Disabled via config (compileOnly)`,
+    },
+  ];
+}
+
+function getPackageSwiftReplacements(providerConfig: ProviderConfig): DependencyReplacement[] {
+  const swiftCommentPrefix = '(?:\\/\\/\\s*)*';
+  const swiftTrailingComment = '(?:\\s*\\/\\/.*)?';
+
+  return [
+    {
+      old: new RegExp(
+        `${swiftCommentPrefix}\\.package\\(url:\\s*"https:\\/\\/github\\.com\\/facebook\\/facebook-ios-sdk\\.git",\\s*\\.upToNextMajor\\(from:\\s*"[^"]+"\\)\\),${swiftTrailingComment}`,
+      ),
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `.package(url: "https://github.com/facebook/facebook-ios-sdk.git", .upToNextMajor(from: "18.0.3")),`
+          : `// .package(url: "https://github.com/facebook/facebook-ios-sdk.git", .upToNextMajor(from: "18.0.3")),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `${swiftCommentPrefix}\\.package\\(url:\\s*"https:\\/\\/github\\.com\\/google\\/GoogleSignIn-iOS\\.git",\\s*\\.upToNextMajor\\(from:\\s*"[^"]+"\\)\\),${swiftTrailingComment}`,
+      ),
+      new:
+        providerConfig.google === 'implementation'
+          ? `.package(url: "https://github.com/google/GoogleSignIn-iOS.git", .upToNextMajor(from: "9.0.0")),`
+          : `// .package(url: "https://github.com/google/GoogleSignIn-iOS.git", .upToNextMajor(from: "9.0.0")),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `${swiftCommentPrefix}\\.package\\(url:\\s*"https:\\/\\/github\\.com\\/Alamofire\\/Alamofire\\.git",\\s*\\.upToNextMajor\\(from:\\s*"[^"]+"\\)\\)${swiftTrailingComment}`,
+      ),
+      new:
+        providerConfig.apple === 'implementation'
+          ? `.package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.11.2"))`
+          : `// .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.11.2"))  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `${swiftCommentPrefix}\\.product\\(name:\\s*"FacebookCore",\\s*package:\\s*"facebook-ios-sdk"\\),${swiftTrailingComment}`,
+      ),
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `.product(name: "FacebookCore", package: "facebook-ios-sdk"),`
+          : `// .product(name: "FacebookCore", package: "facebook-ios-sdk"),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `${swiftCommentPrefix}\\.product\\(name:\\s*"FacebookLogin",\\s*package:\\s*"facebook-ios-sdk"\\),${swiftTrailingComment}`,
+      ),
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `.product(name: "FacebookLogin", package: "facebook-ios-sdk"),`
+          : `// .product(name: "FacebookLogin", package: "facebook-ios-sdk"),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `${swiftCommentPrefix}\\.product\\(name:\\s*"GoogleSignIn",\\s*package:\\s*"GoogleSignIn-iOS"\\),${swiftTrailingComment}`,
+      ),
+      new:
+        providerConfig.google === 'implementation'
+          ? `.product(name: "GoogleSignIn", package: "GoogleSignIn-iOS"),`
+          : `// .product(name: "GoogleSignIn", package: "GoogleSignIn-iOS"),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `${swiftCommentPrefix}\\.product\\(name:\\s*"Alamofire",\\s*package:\\s*"Alamofire"\\)${swiftTrailingComment}`,
+      ),
+      new:
+        providerConfig.apple === 'implementation'
+          ? `.product(name: "Alamofire", package: "Alamofire")`
+          : `// .product(name: "Alamofire", package: "Alamofire")  // Disabled via config (compileOnly)`,
+    },
+  ];
+}
+
 /**
- * Modify Podspec for iOS conditional dependencies
+ * Modify Podspec and Package.swift for iOS conditional dependencies
  */
 function configureIOS(providerConfig: ProviderConfig): void {
   logInfo('Configuring iOS dependencies...');
 
   try {
-    let podspecContent = fs.readFileSync(podspecPath, 'utf8');
+    const podspecResult = applyDependencyReplacements(
+      fs.readFileSync(podspecPath, 'utf8'),
+      getPodspecReplacements(providerConfig),
+    );
 
-    // Replace dependency declarations with conditional ones
-    // Handle both active and commented-out dependencies (including existing disabled comments)
-    const replacements: { old: RegExp; new: string }[] = [
-      {
-        // Google SignIn - handle both active and commented (including existing disabled comments)
-        old: /(#\s*)?s\.dependency\s+'GoogleSignIn',\s*'~>\s*9\.0\.0'(\s*#.*)?/,
-        new:
-          providerConfig.google === 'implementation'
-            ? `s.dependency 'GoogleSignIn', '~> 9.0.0'`
-            : `# s.dependency 'GoogleSignIn', '~> 9.0.0'  # Disabled via config (compileOnly)`,
-      },
-      {
-        // Facebook Core - handle both active and commented (including existing disabled comments)
-        old: /(#\s*)?s\.dependency\s+'FBSDKCoreKit',\s*'~>\s*18\.0'(\s*#.*)?/,
-        new:
-          providerConfig.facebook === 'implementation'
-            ? `s.dependency 'FBSDKCoreKit', '~> 18.0'`
-            : `# s.dependency 'FBSDKCoreKit', '~> 18.0'  # Disabled via config (compileOnly)`,
-      },
-      {
-        // Facebook Login - handle both active and commented (including existing disabled comments)
-        old: /(#\s*)?s\.dependency\s+'FBSDKLoginKit',\s*'~>\s*18\.0'(\s*#.*)?/,
-        new:
-          providerConfig.facebook === 'implementation'
-            ? `s.dependency 'FBSDKLoginKit', '~> 18.0'`
-            : `# s.dependency 'FBSDKLoginKit', '~> 18.0'  # Disabled via config (compileOnly)`,
-      },
-      {
-        // Alamofire (for Apple) - handle both active and commented (including existing disabled comments)
-        old: /(#\s*)?s\.dependency\s+'Alamofire',\s*'~>\s*5\.10\.2'(\s*#.*)?/,
-        new:
-          providerConfig.apple === 'implementation'
-            ? `s.dependency 'Alamofire', '~> 5.10.2'`
-            : `# s.dependency 'Alamofire', '~> 5.10.2'  # Disabled via config (compileOnly)`,
-      },
-    ];
-
-    let modified = false;
-    for (const replacement of replacements) {
-      if (replacement.old.test(podspecContent)) {
-        const before = podspecContent;
-        podspecContent = podspecContent.replace(replacement.old, replacement.new);
-        if (before !== podspecContent) {
-          modified = true;
-        }
-      }
-    }
-
-    if (modified) {
-      fs.writeFileSync(podspecPath, podspecContent, 'utf8');
+    if (podspecResult.modified) {
+      fs.writeFileSync(podspecPath, podspecResult.content, 'utf8');
       logSuccess('Modified podspec');
     } else {
       logInfo('Podspec already up to date');
     }
   } catch (error) {
     logError(`Error modifying podspec: ${(error as Error).message}`);
+  }
+
+  try {
+    if (!fs.existsSync(packageSwiftPath)) {
+      logWarning('Package.swift not found, skipping Swift Package Manager configuration');
+      return;
+    }
+
+    const packageSwiftResult = applyDependencyReplacements(
+      fs.readFileSync(packageSwiftPath, 'utf8'),
+      getPackageSwiftReplacements(providerConfig),
+    );
+
+    if (packageSwiftResult.modified) {
+      fs.writeFileSync(packageSwiftPath, packageSwiftResult.content, 'utf8');
+      logSuccess('Modified Package.swift');
+    } else {
+      logInfo('Package.swift already up to date');
+    }
+  } catch (error) {
+    logError(`Error modifying Package.swift: ${(error as Error).message}`);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Extend `scripts/configure-dependencies.ts` so iOS Swift Package Manager builds honor `plugins.SocialLogin.providers` from `capacitor.config`.
- Disabled providers now have their `Package.swift` `.package(...)` and `.product(...)` entries commented out, mirroring the existing CocoaPods podspec behavior.
- Update README note: SPM now toggles Alamofire the same way CocoaPods does.

Fixes #432

## Why
Capacitor 7+ defaults to Swift Package Manager on iOS. The existing configure hook updated the podspec and Android `gradle.properties`, but left `Package.swift` untouched, so disabled provider SDKs were still resolved and linked in SPM builds.

## How
- Refactored iOS dependency replacement into shared helpers (`applyDependencyReplacements`, `getPodspecReplacements`, `getPackageSwiftReplacements`).
- `configureIOS()` now updates both `CapgoCapacitorSocialLogin.podspec` and `Package.swift`.
- Swift comment-aware regex handles idempotent enable/disable cycles (commented lines are re-enabled cleanly on subsequent syncs).
- Provider source already uses `#if canImport(...)`, so compiling without optional SDKs remains supported.

## Testing
- `bun run build:scripts` — compiles the hook script.
- `bun run build` — full TypeScript/Rollup build passes.
- `bun run fmt` — formatting applied to `configure-dependencies.ts`.
- Manual hook verification with `CAPACITOR_PLATFORM_NAME=ios` and sample `CAPACITOR_CONFIG` values:
  - `facebook: false` comments out Facebook `.package` / `.product` lines in `Package.swift` and podspec deps.
  - All providers `false` comments out Google, Facebook, and Alamofire SPM entries while keeping Capacitor core.
  - Re-enabling providers restores original `Package.swift` lines.
  - Repeated runs are idempotent (`already up to date`).
  - Android path unchanged (`gradle.properties` still updated correctly).

## Not Tested
- `bun run verify:ios` on macOS (CI will run iOS build).
- End-to-end `cap sync` in a consuming app with SPM (manual hook invocation verified the file mutations).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1955faea-a153-49a6-8b39-0e53f3bff90d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1955faea-a153-49a6-8b39-0e53f3bff90d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-social-login/pr/444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789140973&installation_model_id=430928&pr_number=444&repository=Cap-go%2Fcapacitor-social-login&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-social-login%2Fpull%2F444&signature=3411b5c170c6ab4fa175cc3cd20a42b9c9012cb6b040291411180408e3ccc945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-social-login/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS dependency configuration now updates both CocoaPods and Swift Package Manager settings based on the selected Apple provider.
  * Dependency declarations can be enabled or commented out automatically across supported configuration files.
  * Configuration failures are now reported with a failing status.

* **Documentation**
  * Updated the dependency guidance to reflect CocoaPods and Swift Package Manager behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->