### PR TITLE
fix(ios): honor providers config in Package.swift for SPM builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ export default config;
 - This configuration only affects iOS and Android platforms; it does not affect the web platform.
 - **Important**: Using `false` means the dependency won't be bundled, but the plugin code still compiles against it. Ensure the consuming app includes the dependency if needed.
 - **Facebook**: When `facebook: false`, the Facebook SDK is omitted and the plugin compiles a provider stub in its own package — no `com.facebook.*` classes are shipped (avoids privacy-scanner false positives).
-- **Apple (iOS)**: Basic Sign in with Apple always works via AuthenticationServices (no external SDK). Alamofire is only required when using `redirectUrl` / backend token exchange. CocoaPods toggles Alamofire via `apple: true|false`; SPM always resolves Alamofire from `Package.swift` when the plugin is linked.
+- **Apple (iOS)**: Basic Sign in with Apple always works via AuthenticationServices (no external SDK). Alamofire is only required when using `redirectUrl` / backend token exchange. Both CocoaPods and Swift Package Manager toggle Alamofire via `apple: true|false`.
 - Apple Sign-In on Android uses OAuth flow without external SDK dependencies
 - Twitter uses standard OAuth 2.0 flow without external SDK dependencies
 

--- a/scripts/configure-dependencies.ts
+++ b/scripts/configure-dependencies.ts
@@ -28,6 +28,7 @@ const PLATFORM = process.env.CAPACITOR_PLATFORM_NAME;
 // const androidGradlePath = path.join(PLUGIN_ROOT, 'android', 'build.gradle');
 const gradlePropertiesPath = path.join(PLUGIN_ROOT, 'android', 'gradle.properties');
 const podspecPath = path.join(PLUGIN_ROOT, 'CapgoCapacitorSocialLogin.podspec');
+const packageSwiftPath = path.join(PLUGIN_ROOT, 'Package.swift');
 
 // Default provider configuration (backward compatible)
 const defaultProviders: Record<string, string | boolean> = {
@@ -247,74 +248,172 @@ function configureAndroid(providerConfig: ProviderConfig): void {
 }
 
 // ============================================================================
-// iOS: Podspec Configuration
+// iOS: Podspec and Swift Package Manager Configuration
 // ============================================================================
 
+function applyReplacements(
+  content: string,
+  replacements: { old: RegExp; new: string }[],
+): {
+  content: string;
+  modified: boolean;
+} {
+  let modified = false;
+  let updatedContent = content;
+
+  for (const replacement of replacements) {
+    if (replacement.old.test(updatedContent)) {
+      const before = updatedContent;
+      updatedContent = updatedContent.replace(replacement.old, replacement.new);
+      if (before !== updatedContent) {
+        modified = true;
+      }
+    }
+  }
+
+  return { content: updatedContent, modified };
+}
+
+function getIOSPodspecReplacements(providerConfig: ProviderConfig): { old: RegExp; new: string }[] {
+  return [
+    {
+      // Google SignIn - handle both active and commented (including existing disabled comments)
+      old: /(#\s*)?s\.dependency\s+'GoogleSignIn',\s*'~>\s*9\.0\.0'(\s*#.*)?/,
+      new:
+        providerConfig.google === 'implementation'
+          ? `s.dependency 'GoogleSignIn', '~> 9.0.0'`
+          : `# s.dependency 'GoogleSignIn', '~> 9.0.0'  # Disabled via config (compileOnly)`,
+    },
+    {
+      // Facebook Core - handle both active and commented (including existing disabled comments)
+      old: /(#\s*)?s\.dependency\s+'FBSDKCoreKit',\s*'~>\s*18\.0'(\s*#.*)?/,
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `s.dependency 'FBSDKCoreKit', '~> 18.0'`
+          : `# s.dependency 'FBSDKCoreKit', '~> 18.0'  # Disabled via config (compileOnly)`,
+    },
+    {
+      // Facebook Login - handle both active and commented (including existing disabled comments)
+      old: /(#\s*)?s\.dependency\s+'FBSDKLoginKit',\s*'~>\s*18\.0'(\s*#.*)?/,
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `s.dependency 'FBSDKLoginKit', '~> 18.0'`
+          : `# s.dependency 'FBSDKLoginKit', '~> 18.0'  # Disabled via config (compileOnly)`,
+    },
+    {
+      // Alamofire (for Apple) - handle both active and commented (including existing disabled comments)
+      old: /(#\s*)?s\.dependency\s+'Alamofire',\s*'~>\s*5\.10\.2'(\s*#.*)?/,
+      new:
+        providerConfig.apple === 'implementation'
+          ? `s.dependency 'Alamofire', '~> 5.10.2'`
+          : `# s.dependency 'Alamofire', '~> 5.10.2'  # Disabled via config (compileOnly)`,
+    },
+  ];
+}
+
+function getIOSSPMReplacements(providerConfig: ProviderConfig): { old: RegExp; new: string }[] {
+  const inlineComment = '(?:[ \\t]+//[^\\n]*)?';
+  const trailingComma = ',?';
+
+  return [
+    {
+      old: new RegExp(
+        `(?:\\/\\/\\s*)?\\.package\\(url:\\s*"https:\\/\\/github\\.com\\/facebook\\/facebook-ios-sdk\\.git",\\s*\\.upToNextMajor\\(from:\\s*"[^"]+"\\)\\)${trailingComma}${inlineComment}`,
+      ),
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `.package(url: "https://github.com/facebook/facebook-ios-sdk.git", .upToNextMajor(from: "18.0.3")),`
+          : `// .package(url: "https://github.com/facebook/facebook-ios-sdk.git", .upToNextMajor(from: "18.0.3")),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `(?:\\/\\/\\s*)?\\.package\\(url:\\s*"https:\\/\\/github\\.com\\/google\\/GoogleSignIn-iOS\\.git",\\s*\\.upToNextMajor\\(from:\\s*"[^"]+"\\)\\)${trailingComma}${inlineComment}`,
+      ),
+      new:
+        providerConfig.google === 'implementation'
+          ? `.package(url: "https://github.com/google/GoogleSignIn-iOS.git", .upToNextMajor(from: "9.0.0")),`
+          : `// .package(url: "https://github.com/google/GoogleSignIn-iOS.git", .upToNextMajor(from: "9.0.0")),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `(?:\\/\\/\\s*)?\\.package\\(url:\\s*"https:\\/\\/github\\.com\\/Alamofire\\/Alamofire\\.git",\\s*\\.upToNextMajor\\(from:\\s*"[^"]+"\\)\\)${trailingComma}${inlineComment}`,
+      ),
+      new:
+        providerConfig.apple === 'implementation'
+          ? `.package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.11.2")),`
+          : `// .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.11.2")),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `(?:\\/\\/\\s*)?\\.product\\(name:\\s*"FacebookCore",\\s*package:\\s*"facebook-ios-sdk"\\)${trailingComma}${inlineComment}`,
+      ),
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `.product(name: "FacebookCore", package: "facebook-ios-sdk"),`
+          : `// .product(name: "FacebookCore", package: "facebook-ios-sdk"),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `(?:\\/\\/\\s*)?\\.product\\(name:\\s*"FacebookLogin",\\s*package:\\s*"facebook-ios-sdk"\\)${trailingComma}${inlineComment}`,
+      ),
+      new:
+        providerConfig.facebook === 'implementation'
+          ? `.product(name: "FacebookLogin", package: "facebook-ios-sdk"),`
+          : `// .product(name: "FacebookLogin", package: "facebook-ios-sdk"),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `(?:\\/\\/\\s*)?\\.product\\(name:\\s*"GoogleSignIn",\\s*package:\\s*"GoogleSignIn-iOS"\\)${trailingComma}${inlineComment}`,
+      ),
+      new:
+        providerConfig.google === 'implementation'
+          ? `.product(name: "GoogleSignIn", package: "GoogleSignIn-iOS"),`
+          : `// .product(name: "GoogleSignIn", package: "GoogleSignIn-iOS"),  // Disabled via config (compileOnly)`,
+    },
+    {
+      old: new RegExp(
+        `(?:\\/\\/\\s*)?\\.product\\(name:\\s*"Alamofire",\\s*package:\\s*"Alamofire"\\)${trailingComma}${inlineComment}`,
+      ),
+      new:
+        providerConfig.apple === 'implementation'
+          ? `.product(name: "Alamofire", package: "Alamofire"),`
+          : `// .product(name: "Alamofire", package: "Alamofire"),  // Disabled via config (compileOnly)`,
+    },
+  ];
+}
+
 /**
- * Modify Podspec for iOS conditional dependencies
+ * Modify Podspec and Package.swift for iOS conditional dependencies
  */
 function configureIOS(providerConfig: ProviderConfig): void {
   logInfo('Configuring iOS dependencies...');
 
   try {
-    let podspecContent = fs.readFileSync(podspecPath, 'utf8');
+    const podspecContent = fs.readFileSync(podspecPath, 'utf8');
+    const podspecResult = applyReplacements(podspecContent, getIOSPodspecReplacements(providerConfig));
 
-    // Replace dependency declarations with conditional ones
-    // Handle both active and commented-out dependencies (including existing disabled comments)
-    const replacements: { old: RegExp; new: string }[] = [
-      {
-        // Google SignIn - handle both active and commented (including existing disabled comments)
-        old: /(#\s*)?s\.dependency\s+'GoogleSignIn',\s*'~>\s*9\.0\.0'(\s*#.*)?/,
-        new:
-          providerConfig.google === 'implementation'
-            ? `s.dependency 'GoogleSignIn', '~> 9.0.0'`
-            : `# s.dependency 'GoogleSignIn', '~> 9.0.0'  # Disabled via config (compileOnly)`,
-      },
-      {
-        // Facebook Core - handle both active and commented (including existing disabled comments)
-        old: /(#\s*)?s\.dependency\s+'FBSDKCoreKit',\s*'~>\s*18\.0'(\s*#.*)?/,
-        new:
-          providerConfig.facebook === 'implementation'
-            ? `s.dependency 'FBSDKCoreKit', '~> 18.0'`
-            : `# s.dependency 'FBSDKCoreKit', '~> 18.0'  # Disabled via config (compileOnly)`,
-      },
-      {
-        // Facebook Login - handle both active and commented (including existing disabled comments)
-        old: /(#\s*)?s\.dependency\s+'FBSDKLoginKit',\s*'~>\s*18\.0'(\s*#.*)?/,
-        new:
-          providerConfig.facebook === 'implementation'
-            ? `s.dependency 'FBSDKLoginKit', '~> 18.0'`
-            : `# s.dependency 'FBSDKLoginKit', '~> 18.0'  # Disabled via config (compileOnly)`,
-      },
-      {
-        // Alamofire (for Apple) - handle both active and commented (including existing disabled comments)
-        old: /(#\s*)?s\.dependency\s+'Alamofire',\s*'~>\s*5\.10\.2'(\s*#.*)?/,
-        new:
-          providerConfig.apple === 'implementation'
-            ? `s.dependency 'Alamofire', '~> 5.10.2'`
-            : `# s.dependency 'Alamofire', '~> 5.10.2'  # Disabled via config (compileOnly)`,
-      },
-    ];
-
-    let modified = false;
-    for (const replacement of replacements) {
-      if (replacement.old.test(podspecContent)) {
-        const before = podspecContent;
-        podspecContent = podspecContent.replace(replacement.old, replacement.new);
-        if (before !== podspecContent) {
-          modified = true;
-        }
-      }
-    }
-
-    if (modified) {
-      fs.writeFileSync(podspecPath, podspecContent, 'utf8');
+    if (podspecResult.modified) {
+      fs.writeFileSync(podspecPath, podspecResult.content, 'utf8');
       logSuccess('Modified podspec');
     } else {
       logInfo('Podspec already up to date');
     }
   } catch (error) {
     logError(`Error modifying podspec: ${(error as Error).message}`);
+  }
+
+  try {
+    const packageContent = fs.readFileSync(packageSwiftPath, 'utf8');
+    const packageResult = applyReplacements(packageContent, getIOSSPMReplacements(providerConfig));
+
+    if (packageResult.modified) {
+      fs.writeFileSync(packageSwiftPath, packageResult.content, 'utf8');
+      logSuccess('Modified Package.swift');
+    } else {
+      logInfo('Package.swift already up to date');
+    }
+  } catch (error) {
+    logError(`Error modifying Package.swift: ${(error as Error).message}`);
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #432

## What
- Extend `scripts/configure-dependencies.ts` so the iOS hook updates `Package.swift` in addition to the podspec.
- Disabled providers have their SwiftPM `.package(...)` and `.product(...)` entries commented out, mirroring how CocoaPods `s.dependency` lines are handled today.
- Update README note to reflect that SPM now honors `apple: true|false` for Alamofire.

## Why
- `plugins.SocialLogin.providers` already excludes disabled provider SDKs on Android and iOS CocoaPods builds.
- Capacitor 7+ defaults to Swift Package Manager on iOS, but `Package.swift` was never updated by the hook, so disabled SDKs still resolved and linked.
- This matters for app size and privacy manifests (e.g. Facebook SDK tracking domains when Facebook login is not used).

## How
- Refactored iOS configuration into shared replacement helpers.
- Added `getIOSSPMReplacements()` with regex patterns for Facebook, Google, and Alamofire package/product entries.
- Patterns handle already-commented lines, optional trailing commas (last array items), and inline trailing comments without consuming following comment-only lines.
- `configureIOS()` now writes both `CapgoCapacitorSocialLogin.podspec` and `Package.swift`.

## Testing
- `bun run build:scripts` to compile the hook.
- Manual hook runs with `CAPACITOR_PLATFORM_NAME=ios` and provider configs:
  - `facebook: false`, `apple: false` → Facebook and Alamofire entries commented out in `Package.swift` and podspec.
  - Re-enable all providers → entries restored.
  - Second run with unchanged config → idempotent (`already up to date`).
- `bun run fmt`, `bun run lint`, `bun run check:wiring`, and `bun run build` pass locally.

## Not Tested
- `bun run verify:ios` (requires macOS/Xcode in CI).
- End-to-end `cap sync` in a consuming SPM app (CI packed example verification should cover this).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c39655b7-e71a-41ea-91d8-50ca09166ef8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c39655b7-e71a-41ea-91d8-50ca09166ef8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-social-login/pr/445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789140984&installation_model_id=430928&pr_number=445&repository=Cap-go%2Fcapacitor-social-login&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-social-login%2Fpull%2F445&signature=59a79949f83a533788aac4e87ba54eec1487403c780d8922b796dab839ff2638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-social-login/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

