### PR TITLE
fix(web): close Google login popup and return result under COOP

### DIFF
--- a/src/google-provider.ts
+++ b/src/google-provider.ts
@@ -1,6 +1,7 @@
 import { BaseSocialLogin } from './base';
 import type { AuthorizationCode, GoogleLoginOptions, LoginResult, ProviderResponseMap } from './definitions';
 import { createUserCancelledError, inferUserCancelledError } from './errors';
+import { listenForOAuthResult, markOAuthPopup } from './oauth-popup-bridge';
 
 const GOOGLE_OFFLINE_REFRESH_MESSAGE =
   "Google refresh() is not available when using offline mode. Offline mode only returns serverAuthCode for backend token exchange. Send serverAuthCode to your backend and refresh tokens there, or switch google.mode to 'online' for client-side refresh.";
@@ -162,7 +163,6 @@ export class GoogleSocialLogin extends BaseSocialLogin {
     }
 
     const hash = url.hash.substring(1);
-    console.log('handleOAuthRedirect', url.hash);
 
     if (!hash) return null;
 
@@ -175,8 +175,6 @@ export class GoogleSocialLogin extends BaseSocialLogin {
       const errorDescription = params.get('error_description') || error;
       return { error: errorDescription };
     }
-
-    console.log('handleOAuthRedirect ok');
 
     const accessToken = params.get('access_token');
     const idToken = params.get('id_token');
@@ -340,7 +338,10 @@ export class GoogleSocialLogin extends BaseSocialLogin {
     hostedDomain,
     nonce,
     prompt,
-  }: GoogleLoginOptions & { hostedDomain?: string }): Promise<{ provider: T; result: ProviderResponseMap[T] }> {
+  }: GoogleLoginOptions & { hostedDomain?: string; nonce: string }): Promise<{
+    provider: T;
+    result: ProviderResponseMap[T];
+  }> {
     const uniqueScopes = [...new Set([...(scopes || []), 'openid'])];
 
     const params = new URLSearchParams({
@@ -368,20 +369,12 @@ export class GoogleSocialLogin extends BaseSocialLogin {
       BaseSocialLogin.OAUTH_STATE_KEY,
       JSON.stringify({ provider: 'google', loginType: this.loginType, nonce }),
     );
+    markOAuthPopup(nonce);
     const popup = window.open(url, 'Google Sign In', `width=${width},height=${height},left=${left},top=${top},popup=1`);
 
     let popupClosedInterval: number;
     let timeoutHandle: number;
-
-    // Use BroadcastChannel for cross-origin communication (works when postMessage doesn't)
-    const channelName = `google_oauth_${nonce || Date.now()}`;
-    let broadcastChannel: BroadcastChannel | null = null;
-
-    try {
-      broadcastChannel = new BroadcastChannel(channelName);
-    } catch {
-      // BroadcastChannel not supported, fall back to postMessage only
-    }
+    let removeOAuthListener: (() => void) | null = null;
 
     // This may never return...
     return new Promise((resolve, reject) => {
@@ -390,12 +383,15 @@ export class GoogleSocialLogin extends BaseSocialLogin {
         return;
       }
 
+      let settled = false;
+      let coopErrorDetected = false;
+
       const cleanup = (shouldClose = false) => {
-        window.removeEventListener('message', handleMessage);
         clearInterval(popupClosedInterval);
         clearTimeout(timeoutHandle);
-        if (broadcastChannel) {
-          broadcastChannel.close();
+        if (removeOAuthListener) {
+          removeOAuthListener();
+          removeOAuthListener = null;
         }
         if (shouldClose) {
           try {
@@ -406,100 +402,93 @@ export class GoogleSocialLogin extends BaseSocialLogin {
         }
       };
 
+      const settle = (shouldClose: boolean, action: () => void) => {
+        if (settled) return;
+        settled = true;
+        cleanup(shouldClose);
+        action();
+      };
+
       const processOAuthResponse = (data: Record<string, unknown>) => {
         if (this.loginType === 'online') {
           const { accessToken, idToken } = data as { accessToken?: { token: string }; idToken?: string };
           if (accessToken && idToken) {
             const profile = this.parseJwt(idToken);
             this.persistStateGoogle(accessToken.token, idToken);
-            resolve({
-              provider: 'google' as T,
-              result: {
-                accessToken: {
-                  token: accessToken.token,
+            settle(true, () => {
+              resolve({
+                provider: 'google' as T,
+                result: {
+                  accessToken: {
+                    token: accessToken.token,
+                  },
+                  idToken,
+                  profile: {
+                    email: profile.email || null,
+                    familyName: profile.family_name || null,
+                    givenName: profile.given_name || null,
+                    id: profile.sub || null,
+                    name: profile.name || null,
+                    imageUrl: profile.picture || null,
+                  },
+                  responseType: 'online',
                 },
-                idToken,
-                profile: {
-                  email: profile.email || null,
-                  familyName: profile.family_name || null,
-                  givenName: profile.given_name || null,
-                  id: profile.sub || null,
-                  name: profile.name || null,
-                  imageUrl: profile.picture || null,
-                },
-                responseType: 'online',
-              },
+              });
             });
           } else {
-            reject(new Error('Invalid OAuth response: missing accessToken or idToken'));
+            settle(true, () => {
+              reject(new Error('Invalid OAuth response: missing accessToken or idToken'));
+            });
           }
         } else {
           const { serverAuthCode } = data as { serverAuthCode: string };
           if (!serverAuthCode) {
-            reject(new Error('Invalid OAuth response: missing serverAuthCode'));
+            settle(true, () => {
+              reject(new Error('Invalid OAuth response: missing serverAuthCode'));
+            });
             return;
           }
-          resolve({
-            provider: 'google' as T,
-            result: {
-              responseType: 'offline',
-              serverAuthCode,
-            },
+          settle(true, () => {
+            resolve({
+              provider: 'google' as T,
+              result: {
+                responseType: 'offline',
+                serverAuthCode,
+              },
+            });
           });
         }
       };
 
-      const handleMessage = (event: MessageEvent) => {
-        if (event.origin !== window.location.origin || event.data?.source?.startsWith('angular')) return;
-
-        if (event.data?.type === 'oauth-response') {
-          cleanup(true);
-          processOAuthResponse(event.data);
-        } else if (event.data?.type === 'oauth-error') {
-          cleanup(true);
-          const errorMessage = event.data.error || 'User cancelled the OAuth flow';
-          reject(inferUserCancelledError(errorMessage));
-        }
-        // Don't reject for non-OAuth messages, just ignore them
-      };
-
-      // Listen for BroadcastChannel messages
-      if (broadcastChannel) {
-        broadcastChannel.onmessage = (event: MessageEvent) => {
-          const data = event.data;
-          if (data?.source?.toString().startsWith('angular')) return;
-
-          if (data?.type === 'oauth-response') {
-            cleanup(true);
-            processOAuthResponse(data);
-          } else if (data?.type === 'oauth-error') {
-            cleanup(true);
-            const errorMessage = (data.error as string) || 'User cancelled the OAuth flow';
+      // COOP-safe listener: postMessage + BroadcastChannel + localStorage storage events
+      removeOAuthListener = listenForOAuthResult('google', nonce, {
+        onResponse: processOAuthResponse,
+        onError: (errorMessage) => {
+          settle(true, () => {
             reject(inferUserCancelledError(errorMessage));
-          }
-        };
-      }
-
-      window.addEventListener('message', handleMessage);
+          });
+        },
+      });
 
       // Timeout after 5 minutes
       timeoutHandle = setTimeout(() => {
-        cleanup(true);
-        reject(new Error('OAuth timeout'));
+        settle(true, () => {
+          reject(new Error('OAuth timeout'));
+        });
       }, 300000);
 
       popupClosedInterval = setInterval(() => {
+        if (coopErrorDetected) return;
+
         try {
-          // Check if popup is closed - this may throw cross-origin errors for some providers
           if (popup.closed) {
-            cleanup();
-            reject(createUserCancelledError('Popup closed'));
+            settle(false, () => {
+              reject(createUserCancelledError('Popup closed'));
+            });
           }
         } catch {
-          // Cross-origin error when checking popup.closed - this happens when the popup
-          // navigates to a third-party OAuth provider with strict security settings.
-          // We can't detect if the window was closed, so we rely on timeout and message handlers.
-          clearInterval(popupClosedInterval);
+          // COOP blocks popup.closed while on third-party origin — stop polling, rely on bridge
+          coopErrorDetected = true;
         }
       }, 1000);
     });

--- a/src/oauth-popup-bridge.ts
+++ b/src/oauth-popup-bridge.ts
@@ -1,0 +1,204 @@
+/**
+ * COOP-safe OAuth popup communication bridge.
+ *
+ * When Cross-Origin-Opener-Policy severs window.opener, postMessage and popup.closed
+ * checks fail. This module uses localStorage + storage events and BroadcastChannel
+ * as reliable fallbacks that work across same-origin popup windows.
+ */
+
+export const OAUTH_STATE_KEY = 'social_login_oauth_pending';
+export const OAUTH_POPUP_SESSION_KEY = 'social_login_oauth_popup';
+export const OAUTH_RESULT_KEY_PREFIX = 'social_login_oauth_result_';
+export const OAUTH_DELIVERED_KEY = 'social_login_oauth_delivered';
+
+export const POPUP_WINDOW_NAMES = new Set(['OAuth2Login', 'XLogin', 'Google Sign In', 'Authorization']);
+
+export type OAuthBridgeMessage = Record<string, unknown> & {
+  type: 'oauth-response' | 'oauth-error';
+};
+
+export function getOAuthResultKey(nonce: string): string {
+  return `${OAUTH_RESULT_KEY_PREFIX}${nonce}`;
+}
+
+export function getBroadcastChannelName(provider: string, nonceOrState: string): string {
+  if (provider === 'oauth2') return `oauth2_${nonceOrState}`;
+  if (provider === 'twitter') return `twitter_oauth_${nonceOrState}`;
+  return `google_oauth_${nonceOrState}`;
+}
+
+export function markOAuthPopup(nonce: string): void {
+  try {
+    sessionStorage.removeItem(OAUTH_DELIVERED_KEY);
+    sessionStorage.setItem(OAUTH_POPUP_SESSION_KEY, nonce);
+  } catch {
+    // sessionStorage may be unavailable in some contexts
+  }
+}
+
+export function clearOAuthPopupMarker(): void {
+  try {
+    sessionStorage.removeItem(OAUTH_POPUP_SESSION_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function hasOAuthRedirectParams(): boolean {
+  const { search, hash } = window.location;
+  return (
+    search.includes('code=') ||
+    search.includes('error=') ||
+    hash.includes('access_token=') ||
+    hash.includes('id_token=') ||
+    hash.includes('error=')
+  );
+}
+
+export function isOAuthPopupContext(): boolean {
+  if (typeof window === 'undefined') return false;
+  return !!window.opener || POPUP_WINDOW_NAMES.has(window.name) || !!sessionStorage.getItem(OAUTH_POPUP_SESSION_KEY);
+}
+
+export function shouldAutoFinishOAuthRedirect(): boolean {
+  if (!localStorage.getItem(OAUTH_STATE_KEY)) return false;
+  return isOAuthPopupContext() || hasOAuthRedirectParams();
+}
+
+/**
+ * Deliver OAuth result from popup to opener via all available channels.
+ */
+export function deliverOAuthResult(
+  provider: string,
+  nonceOrState: string | undefined,
+  message: OAuthBridgeMessage,
+): void {
+  // Prevent duplicate delivery when both eager handler and plugin constructor run
+  try {
+    if (sessionStorage.getItem(OAUTH_DELIVERED_KEY)) return;
+    sessionStorage.setItem(OAUTH_DELIVERED_KEY, '1');
+  } catch {
+    // sessionStorage unavailable
+  }
+
+  // postMessage when opener reference is still available
+  try {
+    if (window.opener) {
+      window.opener.postMessage(message, window.location.origin);
+    }
+  } catch {
+    // COOP may block opener access
+  }
+
+  // BroadcastChannel works across same-origin windows without opener
+  if (nonceOrState) {
+    try {
+      const channel = new BroadcastChannel(getBroadcastChannelName(provider, nonceOrState));
+      channel.postMessage(message);
+      channel.close();
+    } catch {
+      // BroadcastChannel not supported
+    }
+  }
+
+  // localStorage + storage event is the most COOP-resilient fallback
+  if (nonceOrState) {
+    try {
+      localStorage.setItem(getOAuthResultKey(nonceOrState), JSON.stringify({ ...message, _ts: Date.now() }));
+    } catch {
+      // localStorage may be full or unavailable
+    }
+  }
+}
+
+export interface OAuthResultListener {
+  onResponse: (data: Record<string, unknown>) => void;
+  onError: (error: string, code?: string) => void;
+}
+
+/**
+ * Listen for OAuth results from popup via postMessage, BroadcastChannel, and localStorage.
+ * Returns a cleanup function.
+ */
+export function listenForOAuthResult(
+  provider: string,
+  nonceOrState: string,
+  handlers: OAuthResultListener,
+): () => void {
+  const resultKey = getOAuthResultKey(nonceOrState);
+  const channelName = getBroadcastChannelName(provider, nonceOrState);
+
+  let broadcastChannel: BroadcastChannel | null = null;
+  try {
+    broadcastChannel = new BroadcastChannel(channelName);
+  } catch {
+    // BroadcastChannel not supported
+  }
+
+  const processData = (data: Record<string, unknown>): boolean => {
+    if (data?.source && String(data.source).startsWith('angular')) return false;
+
+    if (data?.type === 'oauth-response') {
+      handlers.onResponse(data);
+      return true;
+    }
+    if (data?.type === 'oauth-error') {
+      handlers.onError((data.error as string) || 'User cancelled the OAuth flow', data.code as string | undefined);
+      return true;
+    }
+    return false;
+  };
+
+  const handleMessage = (event: MessageEvent) => {
+    if (event.origin !== window.location.origin) return;
+    processData(event.data);
+  };
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key !== resultKey || !event.newValue) return;
+    try {
+      const data = JSON.parse(event.newValue);
+      localStorage.removeItem(resultKey);
+      processData(data);
+    } catch {
+      // ignore parse errors
+    }
+  };
+
+  const handleBroadcast = (event: MessageEvent) => {
+    processData(event.data);
+  };
+
+  window.addEventListener('message', handleMessage);
+  window.addEventListener('storage', handleStorage);
+  if (broadcastChannel) {
+    broadcastChannel.onmessage = handleBroadcast;
+  }
+
+  // Poll localStorage as fallback when storage event is missed (e.g. same-window writes)
+  const pollInterval = window.setInterval(() => {
+    try {
+      const raw = localStorage.getItem(resultKey);
+      if (!raw) return;
+      localStorage.removeItem(resultKey);
+      const data = JSON.parse(raw);
+      processData(data);
+    } catch {
+      // ignore
+    }
+  }, 300);
+
+  return () => {
+    window.removeEventListener('message', handleMessage);
+    window.removeEventListener('storage', handleStorage);
+    clearInterval(pollInterval);
+    if (broadcastChannel) {
+      broadcastChannel.close();
+    }
+    try {
+      localStorage.removeItem(resultKey);
+    } catch {
+      // ignore
+    }
+  };
+}

--- a/src/oauth-popup-redirect.ts
+++ b/src/oauth-popup-redirect.ts
@@ -1,0 +1,139 @@
+/**
+ * Eager OAuth popup redirect handler.
+ *
+ * Capacitor lazily loads the web plugin implementation, so the popup window may
+ * never instantiate SocialLoginWeb after Google redirects back. This module runs
+ * immediately when the package is imported and finishes the OAuth redirect in popup
+ * windows without waiting for plugin initialization.
+ */
+import type { LoginResult } from './definitions';
+import { inferUserCancelledError } from './errors';
+import { GoogleSocialLogin } from './google-provider';
+import {
+  clearOAuthPopupMarker,
+  deliverOAuthResult,
+  OAUTH_STATE_KEY,
+  shouldAutoFinishOAuthRedirect,
+  type OAuthBridgeMessage,
+} from './oauth-popup-bridge';
+import { OAuth2SocialLogin } from './oauth2-provider';
+import { TwitterSocialLogin } from './twitter-provider';
+
+async function parseRedirectResult(): Promise<{
+  provider: string | null;
+  state?: string;
+  nonce?: string;
+  result: LoginResult | { error: string } | null;
+}> {
+  const url = new URL(window.location.href);
+  const stateRaw = localStorage.getItem(OAUTH_STATE_KEY);
+  let provider: string | null = null;
+  let state: string | undefined;
+  let nonce: string | undefined;
+
+  if (stateRaw) {
+    try {
+      const parsed = JSON.parse(stateRaw);
+      provider = parsed.provider ?? null;
+      state = parsed.state;
+      nonce = parsed.nonce;
+    } catch {
+      provider = stateRaw === 'true' ? 'google' : null;
+    }
+  }
+
+  const googleProvider = new GoogleSocialLogin();
+  const oauth2Provider = new OAuth2SocialLogin();
+  const twitterProvider = new TwitterSocialLogin();
+
+  let result: LoginResult | { error: string } | null = null;
+
+  switch (provider) {
+    case 'twitter':
+      result = await twitterProvider.handleOAuthRedirect(url, state);
+      break;
+    case 'oauth2':
+      result = await oauth2Provider.handleOAuthRedirect(url, state);
+      break;
+    case 'google':
+    default:
+      result = googleProvider.handleOAuthRedirect(url);
+      break;
+  }
+
+  return { provider, state, nonce, result };
+}
+
+function buildOAuthMessage(parsed: Awaited<ReturnType<typeof parseRedirectResult>>): OAuthBridgeMessage | null {
+  const { result } = parsed;
+  if (!result) return null;
+
+  if ('error' in result) {
+    const error = inferUserCancelledError(result.error);
+    return {
+      type: 'oauth-error',
+      provider: parsed.provider,
+      error: error.message,
+      ...(error.code ? { code: error.code } : null),
+    };
+  }
+
+  return {
+    type: 'oauth-response',
+    provider: result.provider,
+    ...result.result,
+  };
+}
+
+async function finishOAuthRedirectInPopup(): Promise<void> {
+  const parsed = await parseRedirectResult();
+  const nonceOrState = parsed.nonce ?? parsed.state;
+  const message = buildOAuthMessage(parsed);
+
+  if (!message) {
+    // OAuth params may not be ready yet (SPA router). Retry briefly.
+    if (shouldAutoFinishOAuthRedirect()) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const retryParsed = await parseRedirectResult();
+      const retryMessage = buildOAuthMessage(retryParsed);
+      if (retryMessage) {
+        deliverOAuthResult(retryParsed.provider ?? 'google', retryParsed.nonce ?? retryParsed.state, retryMessage);
+      } else {
+        deliverOAuthResult(parsed.provider ?? 'google', nonceOrState, {
+          type: 'oauth-error',
+          provider: parsed.provider,
+          error: 'OAuth redirect did not contain expected parameters.',
+        });
+      }
+    }
+  } else {
+    deliverOAuthResult(parsed.provider ?? 'google', nonceOrState, message);
+  }
+
+  clearOAuthPopupMarker();
+
+  try {
+    window.close();
+  } catch {
+    // Popup may not be allowed to close itself in some contexts
+  }
+}
+
+function onHashChange(): void {
+  if (!shouldAutoFinishOAuthRedirect()) return;
+  void finishOAuthRedirectInPopup();
+}
+
+export function initOAuthPopupRedirectHandler(): void {
+  if (typeof window === 'undefined') return;
+
+  if (shouldAutoFinishOAuthRedirect()) {
+    void finishOAuthRedirectInPopup();
+  }
+
+  // SPA routers may apply the OAuth hash after initial load
+  window.addEventListener('hashchange', onHashChange);
+}
+
+// Auto-run on import so popup windows finish OAuth even before plugin lazy-load
+initOAuthPopupRedirectHandler();

--- a/src/social-login.ts
+++ b/src/social-login.ts
@@ -1,5 +1,8 @@
 import { registerPlugin } from '@capacitor/core';
 
+// Eagerly finish OAuth popup redirects before plugin lazy-load (COOP-safe)
+import './oauth-popup-redirect';
+
 import type {
   AuthorizationCode,
   AuthorizationCodeOptions,

--- a/src/web.ts
+++ b/src/web.ts
@@ -22,12 +22,18 @@ import type {
 import { inferUserCancelledError } from './errors';
 import { FacebookSocialLogin } from './facebook-provider';
 import { GoogleSocialLogin } from './google-provider';
+import {
+  clearOAuthPopupMarker,
+  deliverOAuthResult,
+  OAUTH_STATE_KEY,
+  shouldAutoFinishOAuthRedirect,
+  type OAuthBridgeMessage,
+} from './oauth-popup-bridge';
 import { OAuth2SocialLogin } from './oauth2-provider';
 import { TwitterSocialLogin } from './twitter-provider';
 
 export class SocialLoginWeb extends WebPlugin implements SocialLoginPlugin {
-  private static readonly OAUTH_STATE_KEY = 'social_login_oauth_pending';
-  private static readonly POPUP_WINDOW_NAMES = new Set(['OAuth2Login', 'XLogin', 'Google Sign In', 'Authorization']);
+  private static readonly OAUTH_STATE_KEY = OAUTH_STATE_KEY;
 
   private googleProvider: GoogleSocialLogin;
   private appleProvider: AppleSocialLogin;
@@ -46,9 +52,8 @@ export class SocialLoginWeb extends WebPlugin implements SocialLoginPlugin {
 
     // Auto-finish OAuth redirects only when running inside a popup window.
     // For redirect-based flows (full page navigation), the app should call `handleRedirectCallback()` explicitly.
-    const hasPending = !!localStorage.getItem(SocialLoginWeb.OAUTH_STATE_KEY);
-    const isPopup = !!window.opener || SocialLoginWeb.POPUP_WINDOW_NAMES.has(window.name);
-    if (hasPending && isPopup) {
+    // Note: oauth-popup-redirect.ts also handles this eagerly on package import for COOP-safe popup completion.
+    if (shouldAutoFinishOAuthRedirect()) {
       this.finishOAuthRedirectInPopup().catch((error) => {
         console.error('Failed to finish OAuth redirect', error);
         try {
@@ -103,14 +108,18 @@ export class SocialLoginWeb extends WebPlugin implements SocialLoginPlugin {
 
   private async finishOAuthRedirectInPopup(): Promise<void> {
     const parsed = await this.parseRedirectResult();
-    const result = parsed.result;
-    if (!result) return;
+    const nonceOrState = parsed.nonce ?? parsed.state;
+    let message: OAuthBridgeMessage;
 
-    // Build the message to send
-    let message: Record<string, unknown>;
-    if ('error' in result) {
+    if (!parsed.result) {
+      message = {
+        type: 'oauth-error',
+        provider: parsed.provider,
+        error: 'OAuth redirect did not contain expected parameters.',
+      };
+    } else if ('error' in parsed.result) {
       const resolvedProvider = parsed.provider ?? null;
-      const error = inferUserCancelledError(result.error);
+      const error = inferUserCancelledError(parsed.result.error);
       message = {
         type: 'oauth-error',
         provider: resolvedProvider,
@@ -120,45 +129,19 @@ export class SocialLoginWeb extends WebPlugin implements SocialLoginPlugin {
     } else {
       message = {
         type: 'oauth-response',
-        provider: result.provider,
-        ...result.result,
+        provider: parsed.result.provider,
+        ...parsed.result.result,
       };
     }
 
-    // Try postMessage first (works when window.opener is accessible)
+    deliverOAuthResult(parsed.provider ?? 'google', nonceOrState, message);
+    clearOAuthPopupMarker();
+
     try {
-      if (window.opener) {
-        window.opener.postMessage(message, window.location.origin);
-      }
+      window.close();
     } catch {
-      // Cross-origin error - window.opener may not be accessible
-      console.log('postMessage to opener failed, using BroadcastChannel');
+      // Popup may not be allowed to close itself in some contexts
     }
-
-    // Also use BroadcastChannel as a fallback (works across same-origin windows
-    // even when window.opener is not accessible due to cross-origin navigation)
-    try {
-      // Determine the channel name based on provider and state/nonce
-      let channelName: string | null = null;
-      if (parsed.provider === 'oauth2' && parsed.state) {
-        channelName = `oauth2_${parsed.state}`;
-      } else if (parsed.provider === 'twitter' && parsed.state) {
-        channelName = `twitter_oauth_${parsed.state}`;
-      } else if (parsed.provider === 'google' && parsed.nonce) {
-        channelName = `google_oauth_${parsed.nonce}`;
-      }
-
-      if (channelName) {
-        const channel = new BroadcastChannel(channelName);
-        channel.postMessage(message);
-        channel.close();
-      }
-    } catch {
-      // BroadcastChannel not supported or other error
-      console.log('BroadcastChannel not available');
-    }
-
-    window.close();
   }
 
   async initialize(options: InitializeOptions): Promise<void> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- Add a COOP-safe OAuth popup bridge (`oauth-popup-bridge.ts`) that delivers auth results via localStorage storage events, BroadcastChannel, and postMessage
- Eagerly finish OAuth popup redirects on package import (`oauth-popup-redirect.ts`) so the popup completes auth before Capacitor lazy-loads the web plugin
- Update Google web login to listen on all bridge channels and stop relying solely on `popup.closed` polling under COOP
- Ensure popup always closes and reports an error when redirect params are missing

Fixes #450 and addresses the regression reported in #341.

## Why
Under Cross-Origin-Opener-Policy, `window.opener` and `popup.closed` checks fail while the popup is on Google's origin. The previous implementation cleared the `popup.closed` poller on the first COOP error and depended on postMessage/BroadcastChannel from a popup callback that only ran after Capacitor lazy-loaded `SocialLoginWeb`. In many apps the popup never instantiated the plugin, so the popup stayed open and the parent login promise never resolved.

## How
- **`oauth-popup-bridge.ts`**: Shared transport layer with `deliverOAuthResult()` (popup → parent) and `listenForOAuthResult()` (parent listener). Uses localStorage + `storage` events as the most COOP-resilient channel, with BroadcastChannel and postMessage as additional paths.
- **`oauth-popup-redirect.ts`**: Side-effect import from `social-login.ts` that detects pending OAuth state + redirect params and finishes the flow immediately, including a brief retry and `hashchange` listener for SPA routers.
- **`google-provider.ts`**: Marks popup session on open, uses bridge listener instead of manual BroadcastChannel setup, and stops clearing the `popup.closed` interval on COOP errors (uses a flag instead).
- **`web.ts`**: Reuses bridge for popup completion; always closes popup and delivers result/error instead of returning early on null parse.

## Testing
- `bun run build` — passes
- `bun run fmt` — passes (pre-existing warnings only)
- `bun run lint` — passes (pre-existing warnings only)

## Not Tested
- Live browser Google OAuth popup flow with COOP headers (requires dev app + Google client ID)
- Android/iOS Google login (unchanged native code paths)
- OAuth2/Twitter popup flows (benefit from shared `web.ts` bridge delivery but parent listeners not updated)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97d6ae4b-a6e6-4764-8a1a-cfa9746dd1cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97d6ae4b-a6e6-4764-8a1a-cfa9746dd1cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-social-login/pr/451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789964537&installation_model_id=430928&pr_number=451&repository=Cap-go%2Fcapacitor-social-login&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-social-login%2Fpull%2F451&signature=e4926835946b4053c21720b7e35a78e80fbe75bd797f4d6bf6f8ce282a32445d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-social-login/pull/451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable OAuth popup communication across browser security contexts.
  * OAuth popups now automatically process redirect results and close after completion.
  * Added clearer handling for missing, delayed, or failed OAuth responses.

* **Bug Fixes**
  * Prevented duplicate OAuth completion and improved cleanup after authentication.
  * Improved compatibility with browsers using Cross-Origin-Opener-Policy (COOP).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->