### PR TITLE
fix(ios): preserve id_token for OAuth2 logout id_token_hint

### DIFF
--- a/ios/Sources/SocialLoginPlugin/OAuth2Provider.swift
+++ b/ios/Sources/SocialLoginPlugin/OAuth2Provider.swift
@@ -385,6 +385,7 @@ class OAuth2Provider: NSObject {
     }
 
     func logout(providerId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        let storedIdToken = loadTokens(for: providerId)?.idToken
         UserDefaults.standard.removeObject(forKey: tokenStorageKey(for: providerId))
         ensureDiscovered(providerId: providerId) { [weak self] res in
             guard let self = self else {
@@ -395,7 +396,7 @@ class OAuth2Provider: NSObject {
                 var url = base
                 if var components = URLComponents(url: base, resolvingAgainstBaseURL: false) {
                     var items = components.queryItems ?? []
-                    if let idToken = self.loadTokens(for: providerId)?.idToken, !idToken.isEmpty {
+                    if let idToken = storedIdToken, !idToken.isEmpty {
                         items.append(URLQueryItem(name: "id_token_hint", value: idToken))
                     }
                     if let post = config.postLogoutRedirectUrl, !post.isEmpty {


### PR DESCRIPTION
## What

- Fix iOS `OAuth2Provider.logout()` so it captures the stored `id_token` before clearing token storage.

## Why

- `logout()` called `UserDefaults.standard.removeObject(...)` first, then tried to read the `id_token` from storage afterwards to build the `id_token_hint` query parameter for the RP-initiated logout URL. Since the tokens were already deleted, `id_token_hint` was never sent. Providers that rely on this hint might not be able to reliably terminate the user's session.

## How

- Read `idToken` via `loadTokens(...)` before removing the stored tokens, and use that captured value when building the end-session URL instead of re-reading (now-deleted) storage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-social-login/pr/459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791364293&installation_model_id=430928&pr_number=459&repository=Cap-go%2Fcapacitor-social-login&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-social-login%2Fpull%2F459&signature=67012f6a825384d59f549e7a1bb796d46c7771311c747b415b30316d0e00ca84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-social-login/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logout handling for iOS OAuth providers by ensuring the stored ID token is included when ending a session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->